### PR TITLE
Fix compilation with Buidler

### DIFF
--- a/contracts/ActivePool.sol
+++ b/contracts/ActivePool.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.5.11;
 
 import './IPool.sol';
-import '../node_modules/@openzeppelin/contracts/ownership/Ownable.sol';
-import "../node_modules/@openzeppelin/contracts/math/SafeMath.sol";
+import '@openzeppelin/contracts/ownership/Ownable.sol';
+import '@openzeppelin/contracts/math/SafeMath.sol';
 
 contract ActivePool is Ownable, IPool {
     using SafeMath for uint256;

--- a/contracts/CDPManager.sol
+++ b/contracts/CDPManager.sol
@@ -7,8 +7,8 @@ import "./IPriceFeed.sol";
 import "./ISortedCDPs.sol";
 import "./IPoolManager.sol";
 import "./DeciMath.sol";
-import "../node_modules/@openzeppelin/contracts/math/SafeMath.sol";
-import "../node_modules/@openzeppelin/contracts/ownership/Ownable.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/ownership/Ownable.sol";
 
 contract CDPManager is Ownable, ICDPManager {
     using SafeMath for uint;

--- a/contracts/CLVToken.sol
+++ b/contracts/CLVToken.sol
@@ -1,11 +1,11 @@
 pragma solidity ^0.5.11;
 
 import "./ICLVToken.sol";
-import "../node_modules/@openzeppelin/contracts/GSN/Context.sol";
-import "../node_modules/@openzeppelin/contracts/math/SafeMath.sol";
-import "../node_modules/@openzeppelin/contracts/ownership/Ownable.sol";
-import "../node_modules/@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "../node_modules/@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/GSN/Context.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/ownership/Ownable.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./CLVTokenData.sol";
 
 contract CLVToken is IERC20, ICLVToken, Ownable {

--- a/contracts/CLVTokenData.sol
+++ b/contracts/CLVTokenData.sol
@@ -2,8 +2,8 @@ pragma solidity ^0.5.11;
 
 // Stores the CLV user data: token balances and spending allowances.
 // Functions are setters, addition and subtraction. Actual token logic resides in CLVToken.sol
-import "../node_modules/@openzeppelin/contracts/math/SafeMath.sol";
-import "../node_modules/@openzeppelin/contracts/ownership/Ownable.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/ownership/Ownable.sol";
 
 contract CLVTokenData is Ownable {
     using SafeMath for uint;

--- a/contracts/DeciMath.sol
+++ b/contracts/DeciMath.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.11;
 
-import "../node_modules/@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
 
 library DeciMath {
     /* 

--- a/contracts/NameRegistry.sol
+++ b/contracts/NameRegistry.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.11;
 
-import "../node_modules/@openzeppelin/contracts/ownership/Ownable.sol";
+import "@openzeppelin/contracts/ownership/Ownable.sol";
 
 contract NameRegistry is Ownable {
 

--- a/contracts/PoolManager.sol
+++ b/contracts/PoolManager.sol
@@ -7,8 +7,8 @@ import './IStabilityPool.sol';
 import './IPriceFeed.sol';
 import './ICLVToken.sol';
 import './DeciMath.sol';
-import '../node_modules/@openzeppelin/contracts/math/SafeMath.sol';
-import '../node_modules/@openzeppelin/contracts/ownership/Ownable.sol';
+import '@openzeppelin/contracts/math/SafeMath.sol';
+import '@openzeppelin/contracts/ownership/Ownable.sol';
 
 // PoolManager maintains all pools 
 contract PoolManager is Ownable, IPoolManager {

--- a/contracts/PriceFeed.sol
+++ b/contracts/PriceFeed.sol
@@ -1,8 +1,7 @@
 pragma solidity ^0.5.11;
 
-import "../node_modules/@openzeppelin/contracts/math/SafeMath.sol";
-import '../node_modules/@openzeppelin/contracts/ownership/Ownable.sol';
-import '../node_modules/@openzeppelin/contracts/ownership/Ownable.sol';
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import '@openzeppelin/contracts/ownership/Ownable.sol';
 import './ICDPManager.sol';
 
 // A mock ETH:USD price oracle

--- a/contracts/SortedCDPs.sol
+++ b/contracts/SortedCDPs.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.5.11;
 
 import "./ICDPManager.sol";
-import '../node_modules/@openzeppelin/contracts/math/SafeMath.sol';
-import "../node_modules/@openzeppelin/contracts/ownership/Ownable.sol";
+import '@openzeppelin/contracts/math/SafeMath.sol';
+import "@openzeppelin/contracts/ownership/Ownable.sol";
 
 /* 
 A sorted doubly linked list with nodes sorted in descending order, based on current ICRs of active CDPs. 

--- a/contracts/StabilityPool.sol
+++ b/contracts/StabilityPool.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.5.11;
 
 import './IStabilityPool.sol';
-import '../node_modules/@openzeppelin/contracts/ownership/Ownable.sol';
-import '../node_modules/@openzeppelin/contracts/math/SafeMath.sol';
+import '@openzeppelin/contracts/ownership/Ownable.sol';
+import '@openzeppelin/contracts/math/SafeMath.sol';
 
 contract StabilityPool is Ownable, IStabilityPool {
     using SafeMath for uint256;


### PR DESCRIPTION
Buidler refuses to treat library files as local ones.
https://buidler.dev/errors/#BDLR402

Instead of:
`import './node_modules/library_name/.../ContractName.sol';`
can simply do:
`import 'library_name/.../ContractName.sol';`

This also works with Truffle.