### PR TITLE
Only build (and push) Docker image on push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
       - name: Build frontend Docker image
+        if: ${{ github.event_name == 'push' }}
         run: |
           docker-compose build
           docker-compose push


### PR DESCRIPTION
Frontends built from pull requests should not be published as
official on Docker hub.

Creating this pull request to verify that it doesn't happen ;-)