### PR TITLE
contracts: Restrict ETH flows

### DIFF
--- a/packages/contracts/contracts/ActivePool.sol
+++ b/packages/contracts/contracts/ActivePool.sol
@@ -10,7 +10,6 @@ contract ActivePool is Ownable, IPool {
 
     address public poolManagerAddress;
     address public cdpManagerAddress;
-    address public stabilityPoolAddress;
     address public defaultPoolAddress;
     uint256 internal ETH;  // deposited ether tracker
     uint256 internal CLVDebt;
@@ -26,12 +25,11 @@ contract ActivePool is Ownable, IPool {
         _;
     }
 
-    modifier onlyPoolManagerOrPool {
+    modifier onlyPoolManagerOrDefaultPool {
         require(
             _msgSender() == poolManagerAddress || 
-            _msgSender() == stabilityPoolAddress || 
-            _msgSender() == defaultPoolAddress, 
-            "ActivePool: Caller is neither the PoolManager nor a Pool");
+            _msgSender() == defaultPoolAddress,
+            "ActivePool: Caller is neither the PoolManager nor Default Pool");
         _;
     }
 
@@ -48,8 +46,7 @@ contract ActivePool is Ownable, IPool {
     function setAddresses(
         address _poolManagerAddress,
         address _cdpManagerAddress,
-        address _defaultPoolAddress,
-        address _stabilityPoolAddress
+        address _defaultPoolAddress
     )
         external
         onlyOwner
@@ -57,12 +54,10 @@ contract ActivePool is Ownable, IPool {
         poolManagerAddress = _poolManagerAddress;
         cdpManagerAddress = _cdpManagerAddress;
         defaultPoolAddress = _defaultPoolAddress;
-        stabilityPoolAddress = _stabilityPoolAddress;
 
         emit PoolManagerAddressChanged(_poolManagerAddress);
         emit CDPManagerAddressChanged(_cdpManagerAddress);
-        emit DefaultPoolAddressChanged(defaultPoolAddress);
-        emit StabilityPoolAddressChanged(stabilityPoolAddress);
+        emit DefaultPoolAddressChanged(_defaultPoolAddress);
 
         _renounceOwnership();
     }
@@ -101,7 +96,7 @@ contract ActivePool is Ownable, IPool {
         return address(this).balance;
     }
 
-    function () external payable onlyPoolManagerOrPool {
+    function () external payable onlyPoolManagerOrDefaultPool {
         ETH = ETH.add(msg.value);
     }
 }

--- a/packages/contracts/contracts/CDPManager.sol
+++ b/packages/contracts/contracts/CDPManager.sol
@@ -1227,8 +1227,4 @@ contract CDPManager is LiquityBase, Ownable, ICDPManager {
         CDPs[_user].debt = newDebt;
         return newDebt;
     }
-
-    function () external payable  {
-        require(msg.data.length == 0);
-    }
 }

--- a/packages/contracts/contracts/DefaultPool.sol
+++ b/packages/contracts/contracts/DefaultPool.sol
@@ -9,7 +9,6 @@ contract DefaultPool is Ownable, IPool {
     using SafeMath for uint256;
 
     address public poolManagerAddress;
-    address public stabilityPoolAddress;
     address public activePoolAddress;
     uint256 internal ETH;  // deposited ether tracker
     uint256 internal CLVDebt;  // total outstanding CDP debt
@@ -21,12 +20,8 @@ contract DefaultPool is Ownable, IPool {
         _;
     }
 
-    modifier onlyPoolManagerOrPool {
-        require(
-            _msgSender() == poolManagerAddress || 
-            _msgSender() == stabilityPoolAddress || 
-            _msgSender() == activePoolAddress, 
-            "DefaultPool: Caller is neither the PoolManager nor a Pool");
+    modifier onlyActivePool {
+        require(_msgSender() == activePoolAddress, "DefaultPool: Caller is not ActivePool");
         _;
     }
 
@@ -34,19 +29,16 @@ contract DefaultPool is Ownable, IPool {
 
     function setAddresses(
         address _poolManagerAddress,
-        address _activePoolAddress,
-        address _stabilityPoolAddress
+        address _activePoolAddress
     )
         external
         onlyOwner
     {
         poolManagerAddress = _poolManagerAddress;
         activePoolAddress = _activePoolAddress;
-        stabilityPoolAddress = _stabilityPoolAddress;
 
-        emit PoolManagerAddressChanged(poolManagerAddress);
-        emit ActivePoolAddressChanged(activePoolAddress);
-        emit StabilityPoolAddressChanged(stabilityPoolAddress);
+        emit PoolManagerAddressChanged(_poolManagerAddress);
+        emit ActivePoolAddressChanged(_activePoolAddress);
 
         _renounceOwnership();
     }
@@ -85,7 +77,7 @@ contract DefaultPool is Ownable, IPool {
         return address(this).balance;
     }
 
-    function () external payable onlyPoolManagerOrPool {
+    function () external payable onlyActivePool {
         ETH = ETH.add(msg.value);
     }
 }

--- a/packages/contracts/contracts/Interfaces/IPoolManager.sol
+++ b/packages/contracts/contracts/Interfaces/IPoolManager.sol
@@ -80,5 +80,5 @@ interface IPoolManager {
 
     function withdrawFromSPtoCDP(address _user, address _hint) external;
 
-    function offset(uint _debt, uint _coll) external payable;
+    function offset(uint _debt, uint _coll) external;
 }

--- a/packages/contracts/contracts/Interfaces/IStabilityPool.sol
+++ b/packages/contracts/contracts/Interfaces/IStabilityPool.sol
@@ -23,8 +23,7 @@ interface IStabilityPool {
 
     function setAddresses(
         address _poolManagerAddress,
-        address _activePoolAddress,
-        address _defaultPoolAddress
+        address _activePoolAddress
     ) external;
 
     function sendETH(address _account, uint _amount) external;

--- a/packages/contracts/contracts/PoolManager.sol
+++ b/packages/contracts/contracts/PoolManager.sol
@@ -108,10 +108,10 @@ contract PoolManager is Ownable, IPoolManager {
         _;
     }
 
-    modifier onlyStabilityPoolorActivePool {
+    modifier onlyStabilityPool {
         require(
-            _msgSender() == stabilityPoolAddress ||  _msgSender() ==  activePoolAddress, 
-            "PoolManager: Caller is neither StabilityPool nor ActivePool");
+            _msgSender() == stabilityPoolAddress,
+            "PoolManager: Caller is not StabilityPool");
         _;
     }
 
@@ -477,8 +477,7 @@ contract PoolManager is Ownable, IPoolManager {
     Only called from liquidation functions in CDPManager. */
     function offset(uint _debtToOffset, uint _collToAdd) 
     external 
-    payable 
-    onlyCDPManager 
+    onlyCDPManager
     {    
         uint totalCLVDeposits = stabilityPool.getTotalCLVDeposits();
         if (totalCLVDeposits == 0 || _debtToOffset == 0) { return; }
@@ -565,5 +564,5 @@ contract PoolManager is Ownable, IPoolManager {
         require(cdpManager.getCDPStatus(_user) == 1, "CDPManager: caller must have an active trove to withdraw ETHGain to");
     }
 
-    function () external payable onlyStabilityPoolorActivePool {}
-}    
+    function () external payable onlyStabilityPool {}
+}

--- a/packages/contracts/contracts/StabilityPool.sol
+++ b/packages/contracts/contracts/StabilityPool.sol
@@ -9,7 +9,6 @@ contract StabilityPool is Ownable, IStabilityPool {
     using SafeMath for uint256;
 
     address public poolManagerAddress;
-    address public defaultPoolAddress;
     address public activePoolAddress;
     uint256 internal ETH;  // deposited ether tracker
     
@@ -23,12 +22,8 @@ contract StabilityPool is Ownable, IStabilityPool {
         _;
     }
 
-    modifier onlyPoolManagerOrPool {
-        require(
-            _msgSender() == poolManagerAddress || 
-            _msgSender() == activePoolAddress || 
-            _msgSender() == defaultPoolAddress, 
-            "StabilityPool: Caller is neither the PoolManager nor a Pool");
+    modifier onlyActivePool {
+        require(_msgSender() == activePoolAddress, "StabilityPool: Caller is not ActivePool");
         _;
     }
 
@@ -36,18 +31,16 @@ contract StabilityPool is Ownable, IStabilityPool {
 
     function setAddresses(
         address _poolManagerAddress,
-        address _activePoolAddress,
-        address _defaultPoolAddress
+        address _activePoolAddress
     )
         external
         onlyOwner
     {
         poolManagerAddress = _poolManagerAddress;
         activePoolAddress = _activePoolAddress;
-        defaultPoolAddress = _defaultPoolAddress;
 
-        emit PoolManagerAddressChanged(poolManagerAddress);
-        emit ActivePoolAddressChanged(activePoolAddress);
+        emit PoolManagerAddressChanged(_poolManagerAddress);
+        emit ActivePoolAddressChanged(_activePoolAddress);
 
         _renounceOwnership();
     }
@@ -89,7 +82,7 @@ contract StabilityPool is Ownable, IStabilityPool {
         return address(this).balance;
     }
 
-    function () external payable onlyPoolManagerOrPool {
+    function () external payable onlyActivePool {
         ETH = ETH.add(msg.value);
     }
 }

--- a/packages/contracts/test/AccessControlTest.js
+++ b/packages/contracts/test/AccessControlTest.js
@@ -284,14 +284,14 @@ contract('All Liquity functions with intra-system access control restrictions', 
 
 
     // fallback (payment)
-    it("fallback(): reverts when called by an account that is neither StabilityPool nor ActivePool", async () => {
+    it("fallback(): reverts when called by an account that is not StabilityPool", async () => {
       // Attempt call from alice
       try {
         txAlice = await web3.eth.sendTransaction({ from: alice, to: poolManager.address, value: 100 })
         assert.fail(txAlice)
       } catch (err) {
         assert.include(err.message, "revert")
-        assert.include(err.message, "Caller is neither StabilityPool nor ActivePool")
+        assert.include(err.message, "Caller is not StabilityPool")
       }
     })
   })
@@ -339,14 +339,14 @@ contract('All Liquity functions with intra-system access control restrictions', 
     // --- onlyPoolManagerOrPool ---
 
     // fallback (payment)	
-    it("fallback(): reverts when called by an account that is neither PoolManager nor a Pool", async () => {
+    it("fallback(): reverts when called by an account that is neither PoolManager nor Default Pool", async () => {
       // Attempt call from alice
       try {
         txAlice = await web3.eth.sendTransaction({ from: alice, to: activePool.address, value: 100 })
         assert.fail(txAlice)
       } catch (err) {
         assert.include(err.message, "revert")
-        assert.include(err.message, "Caller is neither the PoolManager nor a Pool")
+        assert.include(err.message, "ActivePool: Caller is neither the PoolManager nor Default Pool")
       }
     })
   })
@@ -391,14 +391,14 @@ contract('All Liquity functions with intra-system access control restrictions', 
     // --- onlyPoolManagerOrPool ---
 
     // fallback (payment)	
-    it("fallback(): reverts when called by an account that is neither PoolManager nor a Pool", async () => {
+    it("fallback(): reverts when called by an account that is not the Active Pool", async () => {
       // Attempt call from alice
       try {
         txAlice = await web3.eth.sendTransaction({ from: alice, to: defaultPool.address, value: 100 })
         assert.fail(txAlice)
       } catch (err) {
         assert.include(err.message, "revert")
-        assert.include(err.message, "Caller is neither the PoolManager nor a Pool")
+        assert.include(err.message, "DefaultPool: Caller is not ActivePool")
       }
     })
   })
@@ -442,14 +442,14 @@ contract('All Liquity functions with intra-system access control restrictions', 
     // --- onlyPoolManagerOrPool ---
 
     // fallback (payment)	
-    it("fallback(): reverts when called by an account that is neither PoolManager nor a Pool", async () => {
+    it("fallback(): reverts when called by an account that is not the Active Pool", async () => {
       // Attempt call from alice
       try {
         txAlice = await web3.eth.sendTransaction({ from: alice, to: stabilityPool.address, value: 100 })
         assert.fail(txAlice)
       } catch (err) {
         assert.include(err.message, "revert")
-        assert.include(err.message, "Caller is neither the PoolManager nor a Pool")
+        assert.include(err.message, "StabilityPool: Caller is not ActivePool")
       }
     })
   })

--- a/packages/contracts/test/ConnectContractsTest.js
+++ b/packages/contracts/test/ConnectContractsTest.js
@@ -196,26 +196,11 @@ contract('Deployment script - Sets correct contract addresses dependencies after
     assert.equal(defaultPoolAddress, recordedDefaultPoolAddress)
   })
 
-  it('sets the correct StabilityPool address in ActivePool', async () => {
-    const stabilityPoolAddress = stabilityPool.address
-
-    const recordedStabilityPoolAddress = await activePool.stabilityPoolAddress()
-
-    assert.equal(stabilityPoolAddress, recordedStabilityPoolAddress)
-  })
-
   it('sets the correct PoolManager address in StabilityPool', async () => {
     const poolManagerAddress = poolManager.address
 
     const recordedPoolManagerAddress = await stabilityPool.poolManagerAddress()
     assert.equal(poolManagerAddress, recordedPoolManagerAddress)
-  })
-
-  it('sets the correct DefaultPool address in StabilityPool', async () => {
-    const defaultPoolAddress = defaultPool.address
-
-    const recordedDefaultPoolAddress = await stabilityPool.defaultPoolAddress()
-    assert.equal(defaultPoolAddress, recordedDefaultPoolAddress)
   })
 
   it('sets the correct ActivePool address in StabilityPool', async () => {
@@ -237,13 +222,6 @@ contract('Deployment script - Sets correct contract addresses dependencies after
 
     const recordedActivePoolAddress = await defaultPool.activePoolAddress()
     assert.equal(activePoolAddress, recordedActivePoolAddress)
-  })
-
-  it('sets the correct StabilityPool address in DefaultPool', async () => {
-    const stabilityPoolAddress = stabilityPool.address
-
-    const recordedStabilityPoolAddress = await defaultPool.stabilityPoolAddress()
-    assert.equal(stabilityPoolAddress, recordedStabilityPoolAddress)
   })
 
   it('sets the correct CDPManager address in SortedCDPs', async () => {

--- a/packages/contracts/test/PoolsTest.js
+++ b/packages/contracts/test/PoolsTest.js
@@ -18,10 +18,10 @@ contract('StabilityPool', async accounts => {
   */
   let stabilityPool
 
-  const [owner, mockPoolManagerAddress, alice] = accounts;
+  const [owner, mockPoolManagerAddress, mockActivePoolAddress, alice] = accounts;
   beforeEach(async () => {
     stabilityPool = await StabilityPool.new()
-    await stabilityPool.setAddresses(mockPoolManagerAddress, ZERO_ADDRESS, ZERO_ADDRESS)
+    await stabilityPool.setAddresses(mockPoolManagerAddress, mockActivePoolAddress)
   })
 
   it('poolManagerAddress(): gets the poolManager address', async () => {
@@ -65,7 +65,7 @@ contract('StabilityPool', async accounts => {
     // setup: give pool 2 ether
     const stabilityPool_initialBalance = web3.utils.toBN(await web3.eth.getBalance(stabilityPool.address))
     assert.equal(stabilityPool_initialBalance, 0)
-    await web3.eth.sendTransaction({ from: mockPoolManagerAddress, to: stabilityPool.address, value: dec(2, 'ether') }) // start pool with 2 ether 
+    await web3.eth.sendTransaction({ from: mockActivePoolAddress, to: stabilityPool.address, value: dec(2, 'ether') }) // start pool with 2 ether 
 
     const stabilityPool_BalanceBeforeTx = web3.utils.toBN(await web3.eth.getBalance(stabilityPool.address))
     const alice_Balance_BeforeTx = web3.utils.toBN(await web3.eth.getBalance(alice))
@@ -91,7 +91,7 @@ contract('ActivePool', async accounts => {
   const [owner, mockPoolManagerAddress, alice] = accounts;
   beforeEach(async () => {
     activePool = await ActivePool.new()
-    await activePool.setAddresses(mockPoolManagerAddress, ZERO_ADDRESS, ZERO_ADDRESS, ZERO_ADDRESS)
+    await activePool.setAddresses(mockPoolManagerAddress, ZERO_ADDRESS, ZERO_ADDRESS)
   })
 
   it('poolManagerAddress(): gets the poolManager address', async () => {
@@ -158,10 +158,10 @@ contract('DefaultPool', async accounts => {
  
   let defaultPool
 
-  const [owner, mockPoolManagerAddress, alice] = accounts;
+  const [owner, mockPoolManagerAddress, mockActivePoolAddress, alice] = accounts;
   beforeEach(async () => {
     defaultPool = await DefaultPool.new()
-    await defaultPool.setAddresses(mockPoolManagerAddress, ZERO_ADDRESS, ZERO_ADDRESS)
+    await defaultPool.setAddresses(mockPoolManagerAddress, mockActivePoolAddress)
   })
 
   it('poolManagerAddress(): gets the poolManager address', async () => {
@@ -205,7 +205,7 @@ contract('DefaultPool', async accounts => {
     // setup: give pool 2 ether
     const defaultPool_initialBalance = web3.utils.toBN(await web3.eth.getBalance(defaultPool.address))
     assert.equal(defaultPool_initialBalance, 0)
-    await web3.eth.sendTransaction({ from: mockPoolManagerAddress, to: defaultPool.address, value: dec(2, 'ether') }) // start pool with 2 ether 
+    await web3.eth.sendTransaction({ from: mockActivePoolAddress, to: defaultPool.address, value: dec(2, 'ether') }) // start pool with 2 ether 
 
     const defaultPool_BalanceBeforeTx = web3.utils.toBN(await web3.eth.getBalance(defaultPool.address))
     const alice_Balance_BeforeTx = web3.utils.toBN(await web3.eth.getBalance(alice))

--- a/packages/contracts/utils/deploymentHelpers.js
+++ b/packages/contracts/utils/deploymentHelpers.js
@@ -171,21 +171,18 @@ const connectContracts = async (contracts, addresses) => {
   // set contracts in the Pools
   await contracts.stabilityPool.setAddresses(
     addresses.PoolManager,
-    addresses.ActivePool,
-    addresses.DefaultPool
+    addresses.ActivePool
   )
 
   await contracts.activePool.setAddresses(
     addresses.PoolManager,
     addresses.CDPManager,
-    addresses.DefaultPool,
-    addresses.StabilityPool
+    addresses.DefaultPool
   )
 
   await contracts.defaultPool.setAddresses(
     addresses.PoolManager,
-    addresses.ActivePool,
-    addresses.StabilityPool
+    addresses.ActivePool
   )
 
   // set contracts in HintHelpers


### PR DESCRIPTION
It seems there some unused paths for ETH. This PR removes them.

See this for more context:

![ETH flows](https://user-images.githubusercontent.com/701095/96622273-06d2a180-130a-11eb-8b10-c0ee74f52ade.png)
