### PR TITLE
Leave partially liquidated trove in the list - don't remove and re-insert

### DIFF
--- a/packages/contracts/contracts/CDPManager.sol
+++ b/packages/contracts/contracts/CDPManager.sol
@@ -1156,7 +1156,7 @@ contract CDPManager is LiquityBase, Ownable, ICDPManager {
     * 1) the total ETH gas compensation from the liquidation sequence
     * 2) The remaining collateral in a partially liquidated trove (if one occurred)
     *
-    * The ETH as compensation must be excluded as it is always sent out at the very end of the liquidation sequence.
+    * The ETH gas compensation must be excluded as it is always sent out at the very end of the liquidation sequence.
     *
     * The partially liquidated trove's remaining collateral stays in the ActivePool, but it is excluded here so the system 
     * can take snapshots before the partially liquidated trove's stake is updated (based on these snapshots). This ensures


### PR DESCRIPTION
In a partial liquidation, we currently close the trove then "resurrect" and re-insert the trove to the list, and pass it its own address, in `_updatePartiallyLiquidatedTrove`. This is because  its ICR will be the same. But since we've _remove_ the trove and re-insert, it's own address won't be in the list! So it will need to traverse the list with no good hint.

This PR makes a slight refactor:  we simply leave the trove in the list (don't remove & re-insert), and we just update its properties. We still zero its stake (and remove from totalStakes) before making new system snapshots and making its new stake.  

It's only a small change, it fixes that reinsert bug and IMO simplifies the code a bit.  