### PR TITLE
Revert "contracts: Undo SortedTroves.sol changes"

### DIFF
--- a/packages/contracts/contracts/SortedTroves.sol
+++ b/packages/contracts/contracts/SortedTroves.sol
@@ -102,13 +102,13 @@ contract SortedTroves is Ownable, ISortedTroves {
     
     function _insert(address _id, uint256 _ICR, uint _price, address _prevId, address _nextId) internal {
         // List must not be full
-        require(!isFull());  
+        require(!isFull(), "SortedTroves: List is full");
         // List must not already contain node
-        require(!contains(_id));  
+        require(!contains(_id), "SortedTroves: List already contains the node");
         // Node id must not be null
-        require(_id != address(0));  
+        require(_id != address(0), "SortedTroves: Id cannot be zero");
         // ICR must be non-zero
-        require(_ICR > 0); 
+        require(_ICR > 0, "SortedTroves: ICR must be positive");
 
         address prevId = _prevId; 
         address nextId = _nextId; 
@@ -157,7 +157,7 @@ contract SortedTroves is Ownable, ISortedTroves {
      */
     function _remove(address _id) internal {
         // List must contain the node
-        require(contains(_id)); 
+        require(contains(_id), "SortedTroves: List does not contain the id");
 
         if (data.size > 1) { 
             // List contains more than a single node
@@ -201,15 +201,15 @@ contract SortedTroves is Ownable, ISortedTroves {
     function reInsert(address _id, uint256 _newICR, uint _price, address _prevId, address _nextId) external override {
         _requireCallerIsBOorTroveM();
         // List must contain the node
-        require(contains(_id));
+        require(contains(_id), "SortedTroves: List does not contain the id");
+        // ICR must be non-zero
+        require(_newICR > 0, "SortedTroves: ICR must be positive");
 
         // Remove node from the list
         _remove(_id);
 
-        if (_newICR > 0) {
-            // Insert node if it has a non-zero ICR
-            _insert(_id, _newICR, _price, _prevId, _nextId);
-        }
+        // Insert node
+        _insert(_id, _newICR, _price, _prevId, _nextId);
     }
 
     /*

--- a/packages/contracts/test/SortedTrovesTest.js
+++ b/packages/contracts/test/SortedTrovesTest.js
@@ -285,7 +285,7 @@ contract('SortedTroves', async accounts => {
         await th.assertRevert(sortedTrovesTester.reInsert(alice, 1, 1, alice, alice), 'SortedTroves: List does not contain the id')
       })
 
-      it.skip('reInsert(): fails if new ICR is zero', async () => {
+      it('reInsert(): fails if new ICR is zero', async () => {
         await sortedTrovesTester.insert(alice, 1, 1, alice, alice)
         assert.isTrue(await sortedTroves.contains(alice), 'list should contain element')
         await th.assertRevert(sortedTrovesTester.reInsert(alice, 0, 1, alice, alice), 'SortedTroves: ICR must be positive')


### PR DESCRIPTION
This reverts commit a7dfc0796b6930ff59331b77d48527a32865d513 and
restores SortedTroves changes to:

- Add require messages
- Revert if reinserting a trove with zero ICR