### PR TITLE
contracts: Address follow-up audit issues related to Unipool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1012,7 +1012,7 @@ Essentially the way it works is:
 
 Our implementation is simpler because funds for rewards will only be added once, on deployment of LQTY token (for more technical details about the differences, see PR #271 on our repo).
 
-The amount of LQTY tokens that will be minted to rewards contract is 1.33M, and the duration of the program will be 30 days. If at some point the total amount of staked tokens is zero, the clock will “stopped”, so the period will be extended by the time during which the staking pool is empty, in order to avoid getting LQTY tokens locked. That also means that the start time for the program will be the event that occurs first: either LQTY token contract is deployed, and therefore LQTY tokens are minted to Unipool contract, or first liquidity provider stakes UNIv2 tokens into it.
+The amount of LQTY tokens that will be minted to rewards contract is 1.33M, and the duration of the program will be 30 days. If at some point the total amount of staked tokens is zero, the clock will be “stopped”, so the period will be extended by the time during which the staking pool is empty, in order to avoid getting LQTY tokens locked. That also means that the start time for the program will be the event that occurs first: either LQTY token contract is deployed, and therefore LQTY tokens are minted to Unipool contract, or first liquidity provider stakes UNIv2 tokens into it.
 
 ## Liquity System Fees
 

--- a/packages/contracts/contracts/LPRewards/Interfaces/IUnipool.sol
+++ b/packages/contracts/contracts/LPRewards/Interfaces/IUnipool.sol
@@ -8,7 +8,7 @@ interface IUnipool {
     function lastTimeRewardApplicable() external view returns (uint256);
     function rewardPerToken() external view returns (uint256);
     function earned(address account) external view returns (uint256);
-    function exit() external;
+    function withdrawAndClaim() external;
     function claimReward() external;
     //function notifyRewardAmount(uint256 reward) external;
 }

--- a/packages/contracts/test/Unipool.js
+++ b/packages/contracts/test/Unipool.js
@@ -192,7 +192,7 @@ contract('Unipool', function ([_, wallet1, wallet2, wallet3, wallet4, bountyAddr
 
       await time.increaseTo(stakeTime1.add(this.DURATION.mul(new BN(2)).div(new BN(3))));
 
-      await this.pool.exit({ from: wallet2 });
+      await this.pool.withdrawAndClaim({ from: wallet2 });
       const exitTime2 = await time.latest();
 
       const timeDiff3 = exitTime2.sub(stakeTime3);
@@ -235,7 +235,7 @@ contract('Unipool', function ([_, wallet1, wallet2, wallet3, wallet4, bountyAddr
 
       await time.increase(this.DURATION.div(new BN(6)));
 
-      await this.pool.exit({ from: wallet1 });
+      await this.pool.withdrawAndClaim({ from: wallet1 });
       const exitTime1 = await time.latest();
 
       expect(await this.pool.periodFinish()).to.be.bignumber.equal(stakeTime1.add(this.DURATION));
@@ -251,7 +251,7 @@ contract('Unipool', function ([_, wallet1, wallet2, wallet3, wallet4, bountyAddr
 
       await time.increase(this.DURATION.div(new BN(6)));
 
-      await this.pool.exit({ from: wallet2 });
+      await this.pool.withdrawAndClaim({ from: wallet2 });
       const exitTime2 = await time.latest();
 
       expect(await this.pool.periodFinish()).to.be.bignumber.equal(stakeTime1.add(this.DURATION));
@@ -279,7 +279,7 @@ contract('Unipool', function ([_, wallet1, wallet2, wallet3, wallet4, bountyAddr
 
       await time.increase(this.DURATION.div(new BN(6)));
 
-      await this.pool.exit({ from: wallet3 });
+      await this.pool.withdrawAndClaim({ from: wallet3 });
       const exitTime3 = await time.latest();
 
       expect(await this.pool.periodFinish()).to.be.bignumber.equal(stakeTime1.add(emptyPeriod1).add(this.DURATION));
@@ -443,7 +443,7 @@ contract('Unipool', function ([_, wallet1, wallet2, wallet3, wallet4, bountyAddr
     });
 
     it('Exit fails', async function () {
-      await assertRevert(this.pool.exit({ from: wallet1 }), "Cannot withdraw 0");
+      await assertRevert(this.pool.withdrawAndClaim({ from: wallet1 }), "Cannot withdraw 0");
     });
   });
 });


### PR DESCRIPTION
- TOB-LQT-016: Renamed `exit` to `withdrawAndClaim` to avoid
confusion.
We want to keep `claimReward` reverting if there’s no reward
available, as we think it makes sense and it’s more consistent with
the rest of the system, where liquidations and redemptions revert in
case of zero final result.
The renamed function is just a wrapper to call 2 functions in one
transaction, so if one of them reverts, the other one must revert
too. The frontend can easily handle this and redirect users to call
only withdraw if there are no rewards available. It wouldn’t make much
sense to call the wrapper if only one function is needed, it would
just add complexity and waste gas.

- Address the comments in “C. Code Quality” related to Unipool
contract too.