### PR TITLE
contracts: Make LQTYStaking.stake revert with zero amount

### DIFF
--- a/packages/contracts/contracts/LQTY/LQTYStaking.sol
+++ b/packages/contracts/contracts/LQTY/LQTYStaking.sol
@@ -85,6 +85,8 @@ contract LQTYStaking is ILQTYStaking, Ownable, CheckContract, BaseMath {
 
     // If caller has a pre-existing stake, send any accumulated ETH and LUSD gains to them. 
     function stake(uint _LQTYamount) external override {
+        _requireNonZeroAmount(_LQTYamount);
+
         uint currentStake = stakes[msg.sender];
 
         uint ETHGain;
@@ -128,18 +130,21 @@ contract LQTYStaking is ILQTYStaking, Ownable, CheckContract, BaseMath {
         
         _updateUserSnapshots(msg.sender);
 
-        uint LQTYToWithdraw = LiquityMath._min(_LQTYamount, currentStake);
+        if (_LQTYamount > 0) {
+            uint LQTYToWithdraw = LiquityMath._min(_LQTYamount, currentStake);
 
-        uint newStake = currentStake.sub(LQTYToWithdraw);
+            uint newStake = currentStake.sub(LQTYToWithdraw);
 
-        // Decrease user's stake and total LQTY staked
-        stakes[msg.sender] = newStake;
-        totalLQTYStaked = totalLQTYStaked.sub(LQTYToWithdraw);  
+            // Decrease user's stake and total LQTY staked
+            stakes[msg.sender] = newStake;
+            totalLQTYStaked = totalLQTYStaked.sub(LQTYToWithdraw);
 
-        // Transfer unstaked LQTY to user
-        lqtyToken.transfer(msg.sender, LQTYToWithdraw);
+            // Transfer unstaked LQTY to user
+            lqtyToken.transfer(msg.sender, LQTYToWithdraw);
 
-        emit StakeChanged(msg.sender, newStake);
+            emit StakeChanged(msg.sender, newStake);
+        }
+
         emit StakingGainsWithdrawn(msg.sender, LUSDGain, ETHGain);
 
         // Send accumulated LUSD and ETH gains to the caller
@@ -217,6 +222,10 @@ contract LQTYStaking is ILQTYStaking, Ownable, CheckContract, BaseMath {
 
     function _requireUserHasStake(uint currentStake) internal pure {  
         require(currentStake > 0, 'LQTYStaking: User must have a non-zero stake');  
+    }
+
+    function _requireNonZeroAmount(uint _amount) internal pure {
+        require(_amount > 0, 'LQTYStaking: Amount must be non-zero');
     }
 
     receive() external payable {

--- a/packages/contracts/test/LQTYStakingFeeRewardsTest.js
+++ b/packages/contracts/test/LQTYStakingFeeRewardsTest.js
@@ -59,6 +59,20 @@ contract('Fee arithmetic tests', async accounts => {
     await deploymentHelper.connectLQTYContractsToCore(LQTYContracts, contracts)
   })
 
+  it('stake(): reverts if amount is zero', async () => {
+    // FF time one year so owner can transfer LQTY
+    await th.fastForwardTime(timeValues.SECONDS_IN_ONE_YEAR, web3.currentProvider)
+
+    // Owner transfers LQTY to staker A
+    await lqtyToken.transfer(A, dec(100, 18), {from: owner})
+
+    // console.log(`A lqty bal: ${await lqtyToken.balanceOf(A)}`)
+
+    // A makes stake
+    await lqtyToken.approve(lqtyStaking.address, dec(100, 18), {from: A})
+    await assertRevert(lqtyStaking.stake(0, {from: A}), "LQTYStaking: Amount must be non-zero")
+  })
+
   it("ETH fee per LQTY staked increases when a redemption fee is triggered and totalStakes > 0", async () => {
     await borrowerOperations.openTrove(th._100pct, dec(1000, 18), whale, whale, {from: whale, value: dec(100, 'ether')})  
     await borrowerOperations.openTrove(th._100pct, dec(100, 18), A, A, {from: A, value: dec(7, 'ether')})  


### PR DESCRIPTION
Besides, add shortcuts for zero amount in unstake.

Fixes #290.