### PR TITLE
Stake decline test

### DIFF
--- a/packages/contracts/.gitignore
+++ b/packages/contracts/.gitignore
@@ -13,6 +13,9 @@
 # Exported function gas costs and test outputs
 /gasTest/outputs
 
+# Trove stake decrease outputs
+/stakeModel/outputs
+
 /secrets.js
 
 /.vscode

--- a/packages/contracts/stakeModel/stake.py
+++ b/packages/contracts/stakeModel/stake.py
@@ -2,8 +2,8 @@
 import random
 
 # params
-number_of_troves = 10
-new_coll = 10e18
+number_of_troves = 20
+new_coll = 1e18
 
 class TimeSeries():
     def __init__(self):
@@ -56,11 +56,11 @@ def make_trove(coll, liquity):
 
 # remove trove and it's stake, but not coll
 def liquidate(idx, liquity):
+    print(f"percent of total coll liquidated: {liquity.troves_list[idx].coll * 100 / liquity.total_coll}%")
     liquity.total_stakes -= liquity.troves_list[idx].stake
-    liquity.total_coll -=  liquity.troves_list[idx].coll
     liquity.troves_list.pop(idx)
     liquity.trove_count -= 1
-
+   
 def liquidate_and_make_new_trove(new_coll, liquity, time_series):
     liquidate(get_rand_trove_idx(liquity), liquity)
     trove = make_trove(new_coll, liquity)
@@ -87,8 +87,6 @@ def close_first_trove():
     liquity.troves_list.pop(0)
     liquity.trove_count -= 1
 
-
-
 ### Program
 
 # Setup - create Liquity and troves
@@ -100,29 +98,36 @@ step = 0
 for i in range(number_of_troves):
     make_trove(1e18, liquity)
 
-print(f"total stakes: {liquity.total_coll}")
-print(f"total coll: {liquity.total_coll}")
-print(f"total troves: {liquity.trove_count}")
+# print(f"total stakes: {liquity.total_coll}")
+# print(f"total coll: {liquity.total_coll}")
+# print(f"total troves: {liquity.trove_count}")
 
 # # Main simulation loop
 for i in range(10000):
     print(f"step: {step}")
     time_series.steps.append(step)
-    # close_first_trove()
     liquidate_oldest_and_make_new_trove(new_coll, liquity, time_series)
 
     print(f"last stake: {time_series.last_stake()}")
     print(f"last coll: {time_series.last_coll()}")
     print(f"liquity total coll: {liquity.total_coll}")
 
-    last_step = step
+    if time_series.last_stake() < 100:
+        print(f"stake became tiny")
+        break
+
     step += 1
 
 
-    
-# with liquidated troves, and new troves, total coll increases forever, but the fraction liquidated decreases.
-# we want to actually the rate of decline of stakes for constant liquidated fraction.
+#Limitation: with 1 trove liquidated and 1 new trove created at each step, total stakes remains constant but total coll increases forever, 
+# Thus, the fraction of total coll liquidated at each step, decreases.
 #
-# we could do that by closing a trove at each step. what's worse for system?  close early trove, or later?
-# later removes a lower stake
+# Ideally we want to measure the rate of decline of stakes for a constant fraction of total liquidated coll.
+#
+# Closing an additional trove at each step would hold total coll constant, but reduce total stakes, and mean that
+# the sim reduces the number of troves over time and stops short at steps = initial number of troves.
+# 
+# TODO: Distribute pending rewards to troves at each sim step
+#
+
 

--- a/packages/contracts/stakeModel/stakePrecisionTest.js
+++ b/packages/contracts/stakeModel/stakePrecisionTest.js
@@ -1,0 +1,155 @@
+const deploymentHelper = require("../utils/deploymentHelpers.js")
+const testHelpers = require("../utils/testHelpers.js")
+const BNConverter = require("../utils/BNConverter.js")
+
+const BorrowerOperationsTester = artifacts.require("./BorrowerOperationsTester.sol")
+const TroveManagerTester = artifacts.require("TroveManagerTester")
+
+const th = testHelpers.TestHelper
+const { randomInt, toBN, dec } = testHelpers.TestHelper
+const { makeDecimal } = BNConverter.BNConverter
+
+const fs = require('fs')
+
+contract('BorrowerOperations', async accounts => {
+
+  const [
+    owner, alice, bob, carol, dennis, whale,
+    A, B, C, D, E, F, G, H,
+    // defaulter_1, defaulter_2,
+    frontEnd_1, frontEnd_2, frontEnd_3] = accounts;
+
+  const bountyAddress = accounts[998]
+  const lpRewardsAddress = accounts[999]
+
+  // const frontEnds = [frontEnd_1, frontEnd_2, frontEnd_3]
+
+  let priceFeed
+  let troveManager
+  let borrowerOperations
+
+  let contracts
+  let data = []
+
+  beforeEach(async () => {
+    contracts = await deploymentHelper.deployLiquityCore()
+    contracts.borrowerOperations = await BorrowerOperationsTester.new()
+    contracts.troveManager = await TroveManagerTester.new()
+    contracts = await deploymentHelper.deployLUSDToken(contracts)
+    const LQTYContracts = await deploymentHelper.deployLQTYContracts(bountyAddress, lpRewardsAddress)
+
+    await deploymentHelper.connectLQTYContracts(LQTYContracts)
+    await deploymentHelper.connectCoreContracts(contracts, LQTYContracts)
+    await deploymentHelper.connectLQTYContractsToCore(LQTYContracts, contracts)
+
+    priceFeed = contracts.priceFeedTestnet
+    lusdToken = contracts.lusdToken
+    sortedTroves = contracts.sortedTroves
+    troveManager = contracts.troveManager
+    activePool = contracts.activePool
+    stabilityPool = contracts.stabilityPool
+    defaultPool = contracts.defaultPool
+    borrowerOperations = contracts.borrowerOperations
+    hintHelpers = contracts.hintHelpers
+
+    lqtyStaking = LQTYContracts.lqtyStaking
+    lqtyToken = LQTYContracts.lqtyToken
+    communityIssuance = LQTYContracts.communityIssuance
+    lockupContractFactory = LQTYContracts.lockupContractFactory
+  })
+
+  it.only("repeatedly add a fresh trove and liquidate it: reduces snapshots ratio over time", async () => {
+    await priceFeed.setPrice(dec(2000, 18))
+  
+    // Setup: Make initial troves
+    const numberOfTroves = 10 
+    const trovesList = []
+    const initialTroves = accounts.slice(0, numberOfTroves)
+
+    let freshColl = toBN(dec(2, 18))
+    let freshDebt = freshColl.mul(toBN(1000))
+
+    for (const account of initialTroves) {
+      await borrowerOperations.openTrove(th._100pct, freshDebt, account, account, { from: account, value: freshColl })
+      trovesList.push(account)
+    }
+
+    await priceFeed.setPrice(dec(1000, 18))
+    const price = await priceFeed.getPrice()
+
+    // Scenario: alternately liquidate the most recent trove, and make a fresh one.
+    let step = 0
+    while (step < 10) {
+      const freshIdx = numberOfTroves + step // index of fresh trove in global accounts list
+      
+      // Liquidate random trove
+      await priceFeed.setPrice(dec(1000, 18))
+     
+      let liquidationFraction = 2
+      let percentLiquidated
+      let liquidatedColl
+      let troveToLiq = trovesList[0]
+  
+      const totalCollateralBeforeLiq = await troveManager.getEntireSystemColl()
+    
+      troveToLiq = trovesList[trovesList.length-1] // liquidate last one
+
+      const { 1: coll, 3: collReward } = await troveManager.getEntireDebtAndColl(troveToLiq)
+      liquidatedColl = coll.add(collReward)
+
+         percentLiquidated = 
+          makeDecimal(
+            liquidatedColl
+              .mul(toBN(dec(100, 18)))
+              .div(totalCollateralBeforeLiq),
+            18
+          )
+
+      // console.log(`trove to liq: ${troveToLiq}`)
+      await troveManager.liquidate(troveToLiq)
+      await trovesList.pop()
+
+      console.log(`liquidated coll: ${makeDecimal(liquidatedColl, 18)}`)
+      console.log(`total coll pre-liq: ${makeDecimal(totalCollateralBeforeLiq, 18)}`)
+      console.log(`percent liquidated: ${percentLiquidated}`)
+
+      // Make fresh trove to keep same number of troves
+      await priceFeed.setPrice(dec(2000, 18))
+      const freshBorrower = accounts[freshIdx]
+      // Make coll of next fresh trove some fraction of total collateral. This determines the rate of stakes decrease.
+      freshColl = totalCollateralBeforeLiq.div(toBN(liquidationFraction)) 
+      freshDebt = freshColl.mul(toBN(1000))
+      
+      await borrowerOperations.openTrove(th._100pct, freshDebt, freshBorrower, freshBorrower, { from: freshBorrower, value: freshColl })
+      trovesList.push(freshBorrower)
+
+  
+      const totalStakesSnapshot = await troveManager.totalStakesSnapshot()
+      const totalCollateralSnapshot = await troveManager.totalCollateralSnapshot()
+      const snapshotsRatio = totalStakesSnapshot
+        .mul(toBN(dec(1, 18)))
+        .div(totalCollateralSnapshot)
+      
+      console.log(`step: ${step}`)
+      console.log(`Snapshots ratio: ${makeDecimal(snapshotsRatio, 18)}`)
+
+      const stepData = [step, snapshotsRatio, "\n"]
+      data.push(`Fraction of total coll liquidated at each step: ${percentLiquidated}%`, "\n")
+      data.push(stepData)
+
+      if (snapshotsRatio.lt(toBN(100))) {
+        console.log("stop: snapshotsRatio became tiny")
+        break
+      }
+
+      step += 1 
+    }
+
+    fs.writeFile('stakeModel/outputs/snapshotsRatioData.csv', data, (err) => {
+      if (err) { console.log(err) } else {
+        console.log("Snapshots ratio data written to stakeModel/outputs/snapshotsRatioData.csv")
+      }
+    })
+  })
+})
+   

--- a/packages/contracts/utils/testHelpers.js
+++ b/packages/contracts/utils/testHelpers.js
@@ -120,20 +120,28 @@ class TestHelper {
     return accountLast2bytes
   }
 
+  static randomFloat(min, max) {
+    return Math.random() * (max - min) + min;
+  }
+
+  static randomInt(min, max) {
+    return Math.floor(this.randomFloat(min, max))
+  }
+  
   static randDecayFactor(min, max) {
-    const amount = Math.random() * (max - min) + min;
+    const amount = this.randomFloat(min, max)
     const amountInWei = web3.utils.toWei(amount.toFixed(18), 'ether')
     return amountInWei
   }
 
   static randAmountInWei(min, max) {
-    const amount = Math.random() * (max - min) + min;
+    const amount = this.randomFloat(min, max)
     const amountInWei = web3.utils.toWei(amount.toString(), 'ether')
     return amountInWei
   }
 
   static randAmountInGWei(min, max) {
-    const amount = Math.floor(Math.random() * (max - min) + min);
+    const amount =this.randomInt(min, max);
     const amountInWei = web3.utils.toWei(amount.toString(), 'gwei')
     return amountInWei
   }
@@ -142,7 +150,7 @@ class TestHelper {
     return web3.utils.toWei(num.toString(), 'ether')
   }
 
-  static appendData(results, message, data) {
+  static appendData(results, message = "", data) {
     data.push(message + `\n`)
     for (const key in results) {
       data.push(key + "," + results[key] + '\n')
@@ -150,7 +158,7 @@ class TestHelper {
   }
 
   static getRandICR(min, max) {
-    const ICR_Percent = (Math.floor(Math.random() * (max - min) + min))
+    const ICR_Percent = randomInt(min, max)
 
     // Convert ICR to a duint
     const ICR = web3.utils.toWei((ICR_Percent * 10).toString(), 'finney')


### PR DESCRIPTION
The test gives us results for the decline in the system snapshots ratio that's used to determine stake, for constant amount liquidated at each step.

The Python script is much faster but unrealistic and somewhat inaccurate as it doesn't redistribute coll rewards properly, they just hang around in the system.