### PR TITLE
Refactoring proposal: generalize FSM logic into a LiquityReducer

### DIFF
--- a/packages/dev-frontend/src/components/Trove/context/TroveViewContext.tsx
+++ b/packages/dev-frontend/src/components/Trove/context/TroveViewContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext } from "react";
 import type { TroveView, TroveEvent } from "./types";
 
-type TroveViewContextType = {
+export type TroveViewContextType = {
   view: TroveView;
   dispatchEvent: (event: TroveEvent) => void;
 };

--- a/packages/lib-react/index.ts
+++ b/packages/lib-react/index.ts
@@ -3,3 +3,5 @@ export * from "./src/components/LiquityStoreProvider";
 export * from "./src/hooks/useLiquityStore";
 export * from "./src/hooks/useLiquityReducer";
 export * from "./src/hooks/useLiquitySelector";
+
+export * from "./src/utils/createLiquityFSM";

--- a/packages/lib-react/src/hooks/useLiquityReducer.ts
+++ b/packages/lib-react/src/hooks/useLiquityReducer.ts
@@ -1,21 +1,22 @@
 import { useCallback, useEffect, useReducer, useRef } from "react";
 
-import { LiquityStoreState } from "@liquity/lib-base";
+import { LiquityStoreListenerParams, LiquityStoreState } from "@liquity/lib-base";
 
 import { equals } from "../utils/equals";
 import { useLiquityStore } from "./useLiquityStore";
 
-export type LiquityStoreUpdate<T = unknown> = {
+export interface LiquityStoreUpdate<T = unknown> extends LiquityStoreListenerParams<T> {
   type: "updateStore";
-  newState: LiquityStoreState<T>;
-  oldState: LiquityStoreState<T>;
-  stateChange: Partial<LiquityStoreState<T>>;
-};
+}
 
-export const useLiquityReducer = <S, A, T>(
-  reduce: (state: S, action: A | LiquityStoreUpdate<T>) => S,
-  init: (storeState: LiquityStoreState<T>) => S
-): [S, (action: A | LiquityStoreUpdate<T>) => void] => {
+export type LiquityReducer<S, A, T = unknown> = (state: S, action: A | LiquityStoreUpdate<T>) => S;
+export type LiquityReducerInitializer<S, T = unknown> = (storeState: LiquityStoreState<T>) => S;
+export type LiquityReducerDispatch<A, T = unknown> = (action: A | LiquityStoreUpdate<T>) => void;
+
+export const useLiquityReducer = <S, A, T = unknown>(
+  reduce: LiquityReducer<S, A, T>,
+  init: LiquityReducerInitializer<S, T>
+): [state: S, dispatch: LiquityReducerDispatch<A, T>] => {
   const store = useLiquityStore<T>();
   const oldStore = useRef(store);
   const state = useRef(init(store.state));

--- a/packages/lib-react/src/utils/createLiquityFSM.ts
+++ b/packages/lib-react/src/utils/createLiquityFSM.ts
@@ -1,0 +1,40 @@
+import { LiquityStoreListenerParams } from "@liquity/lib-base";
+
+import { LiquityReducer } from "../hooks/useLiquityReducer";
+
+export type LiquityFSMTransitions<S extends string, E extends string> = Record<
+  S,
+  Partial<Record<E, S>>
+>;
+
+export type LiquityFSMEvent<E extends string> = {
+  type: "fireFSMEvent";
+  event: E;
+};
+
+export type LiquityFSMReducer<S extends string, E extends string, T = unknown> = LiquityReducer<
+  S,
+  LiquityFSMEvent<E>,
+  T
+>;
+
+const lookupNextState = <S extends string>(
+  transitions: Record<S, Partial<Record<string, S>>>,
+  currentState: S,
+  event: string
+): S => transitions[currentState][event] ?? currentState;
+
+export const createLiquityFSMReducer = <S extends string, E extends string, T = unknown>(
+  transitions: LiquityFSMTransitions<S, E>,
+  mapStoreUpdateToEvent: (params: LiquityStoreListenerParams<T>) => E | undefined
+): LiquityFSMReducer<S, E, T> => (state, action) => {
+  switch (action.type) {
+    case "fireFSMEvent":
+      return lookupNextState(transitions, state, action.event);
+
+    case "updateStore": {
+      const mappedEvent = mapStoreUpdateToEvent(action);
+      return mappedEvent !== undefined ? lookupNextState(transitions, state, mappedEvent) : state;
+    }
+  }
+};


### PR DESCRIPTION
I realized that it's really simple to factor out the TroveViewProvider FSM logic into a new function that produces a LiquityReducer, which can then be used via useLiquityReducer. This could make it easier to apply the same FSM style for the other panels we've planned.