### PR TITLE
devui: panel transitions

### DIFF
--- a/packages/dev-frontend/src/components/Stability/StabilityDepositManager.tsx
+++ b/packages/dev-frontend/src/components/Stability/StabilityDepositManager.tsx
@@ -111,7 +111,10 @@ export const StabilityDepositManager: React.FC = () => {
   const myTransactionState = useMyTransactionState(transactionId);
 
   useEffect(() => {
-    if (myTransactionState.type === "waitingForApproval") {
+    if (
+      myTransactionState.type === "waitingForApproval" ||
+      myTransactionState.type === "waitingForConfirmation"
+    ) {
       dispatch({ type: "startChange" });
     } else if (myTransactionState.type === "failed" || myTransactionState.type === "cancelled") {
       dispatch({ type: "finishChange" });


### PR DESCRIPTION
- use fixed `change` value for trove panel CLOSED or ADJUSTED event 
- persist loading overlay when changing pages