### PR TITLE
devui: add info icon for lqty reward

### DIFF
--- a/packages/dev-frontend/src/components/Stability/ActiveDeposit.tsx
+++ b/packages/dev-frontend/src/components/Stability/ActiveDeposit.tsx
@@ -14,6 +14,7 @@ import { ClaimRewards } from "./actions/ClaimRewards";
 import { useStabilityView } from "./context/StabilityViewContext";
 import { RemainingLQTY } from "./RemainingLQTY";
 import { Yield } from "./Yield";
+import { InfoIcon } from "../InfoIcon";
 
 const selector = ({ stabilityDeposit, trove }: LiquityStoreState) => ({ stabilityDeposit, trove });
 
@@ -75,6 +76,17 @@ export const ActiveDeposit: React.FC = () => {
               amount={stabilityDeposit.lqtyReward.prettify()}
               color={stabilityDeposit.lqtyReward.nonZero && "success"}
               unit={GT}
+              infoIcon={
+                <InfoIcon
+                  tooltip={
+                    <Card variant="tooltip" sx={{ width: "240px" }}>
+                      Although the LQTY rewards accrue every minute, the value on the UI only updates
+                      when a user transacts with the Stability Pool. Therefore you may receive more
+                      rewards than is displayed when you claim or adjust your deposit.
+                    </Card>
+                  }
+                />
+              }
             />
             <Flex sx={{ justifyContent: "flex-end", flex: 1 }}>
               <Yield />

--- a/packages/dev-frontend/src/components/Stability/StabilityActionDescription.tsx
+++ b/packages/dev-frontend/src/components/Stability/StabilityActionDescription.tsx
@@ -39,7 +39,7 @@ export const StabilityActionDescription: React.FC<StabilityActionDescriptionProp
       {(collateralGain || lqtyReward) && (
         <>
           {" "}
-          and claiming{" "}
+          and claiming at least{" "}
           {collateralGain && lqtyReward ? (
             <>
               <Amount>{collateralGain}</Amount> and <Amount>{lqtyReward}</Amount>

--- a/packages/dev-frontend/src/components/Stability/StabilityDepositEditor.tsx
+++ b/packages/dev-frontend/src/components/Stability/StabilityDepositEditor.tsx
@@ -10,6 +10,7 @@ import { COIN, GT } from "../../strings";
 import { Icon } from "../Icon";
 import { EditableRow, StaticRow } from "../Trove/Editor";
 import { LoadingOverlay } from "../LoadingOverlay";
+import { InfoIcon } from "../InfoIcon";
 
 const selectLUSDBalance = ({ lusdBalance }: LiquityStoreState) => lusdBalance;
 
@@ -79,6 +80,17 @@ export const StabilityDepositEditor: React.FC<StabilityDepositEditorProps> = ({
               amount={originalDeposit.lqtyReward.prettify()}
               color={originalDeposit.lqtyReward.nonZero && "success"}
               unit={GT}
+              infoIcon={
+                <InfoIcon
+                  tooltip={
+                    <Card variant="tooltip" sx={{ width: "240px" }}>
+                      Although the LQTY rewards accrue every minute, the value on the UI only updates
+                      when a user transacts with the Stability Pool. Therefore you may receive more
+                      rewards than is displayed when you claim or adjust your deposit.
+                    </Card>
+                  }
+                />
+              }
             />
           </>
         )}

--- a/packages/dev-frontend/src/theme.ts
+++ b/packages/dev-frontend/src/theme.ts
@@ -362,6 +362,7 @@ const theme: Theme = {
       maxWidth: "912px",
       mx: "auto",
       mt: ["40px", 0],
+      mb: ["40px", "40px"],
       px: cardGapX
     },
 


### PR DESCRIPTION
- also leave space at bottom of page (currently panels had no space at the bottom of page (now there's no footer))