### PR TITLE
devui: clarify recovery mode where possible

### DIFF
--- a/packages/dev-frontend/src/components/RiskyTroves.tsx
+++ b/packages/dev-frontend/src/components/RiskyTroves.tsx
@@ -306,7 +306,7 @@ export const RiskyTroves: React.FC<RiskyTrovesProps> = ({ pageSize }) => {
                             color={
                               collateralRatio.gt(CRITICAL_COLLATERAL_RATIO)
                                 ? "success"
-                                : collateralRatio.gt(MINIMUM_COLLATERAL_RATIO)
+                                : collateralRatio.gt(1.2)
                                 ? "warning"
                                 : "danger"
                             }

--- a/packages/dev-frontend/src/components/SystemStats.tsx
+++ b/packages/dev-frontend/src/components/SystemStats.tsx
@@ -7,7 +7,6 @@ import { useLiquitySelector } from "@liquity/lib-react";
 import { useLiquity } from "../hooks/LiquityContext";
 import { COIN, GT } from "../strings";
 import { Statistic } from "./Statistic";
-import { InfoIcon } from "./InfoIcon";
 
 const selectBalances = ({ accountBalance, lusdBalance, lqtyBalance }: LiquityStoreState) => ({
   accountBalance,
@@ -145,22 +144,13 @@ export const SystemStats: React.FC<SystemStatsProps> = ({ variant = "info", show
       >
         {totalCollateralRatioPct.prettify()}
       </Statistic>
-      {total.collateralRatioIsBelowCritical(price) && (
-        <Box color="danger">
-          The system is in Recovery Mode
-          <InfoIcon
-            size="sm"
-            tooltip={
-              <Card variant="tooltip">
-                Recovery Mode is a special system mode triggered when the Total Collateral Ratio
-                (TCR) falls below 150%. It allows the liquidation of Troves with a Collateral Ratio
-                below the TCR (with the liquidation loss being capped at 10% of the Trove’s debt),
-                and restricts operations that would negatively impact the TCR.
-              </Card>
-            }
-          />
-        </Box>
-      )}
+      <Statistic
+        name="Recovery Mode"
+        tooltip="Recovery Mode is activated when the Total Collateral Ratio (TCR) falls below 150%. When active, your Trove can be liquidated if it's collateral ratio is below the TCR. The maximum value you can lose from a liquidation is 10% of your Trove's debt. Operations are also restricted that would negatively impact the TCR."
+      >
+        {total.collateralRatioIsBelowCritical(price) ? <Box color="danger">Yes</Box> : "No"}
+      </Statistic>
+      {}
 
       <Heading as="h2" sx={{ mt: 3, fontWeight: "body" }}>
         Frontend

--- a/packages/dev-frontend/src/components/SystemStats.tsx
+++ b/packages/dev-frontend/src/components/SystemStats.tsx
@@ -146,7 +146,7 @@ export const SystemStats: React.FC<SystemStatsProps> = ({ variant = "info", show
       </Statistic>
       <Statistic
         name="Recovery Mode"
-        tooltip="Recovery Mode is activated when the Total Collateral Ratio (TCR) falls below 150%. When active, your Trove can be liquidated if it's collateral ratio is below the TCR. The maximum collateral you can lose from liquidation is capped at 110% of your Trove's debt. Operations are also restricted that would negatively impact the TCR."
+        tooltip="Recovery Mode is activated when the Total Collateral Ratio (TCR) falls below 150%. When active, your Trove can be liquidated if its collateral ratio is below the TCR. The maximum collateral you can lose from liquidation is capped at 110% of your Trove's debt. Operations are also restricted that would negatively impact the TCR."
       >
         {total.collateralRatioIsBelowCritical(price) ? <Box color="danger">Yes</Box> : "No"}
       </Statistic>

--- a/packages/dev-frontend/src/components/SystemStats.tsx
+++ b/packages/dev-frontend/src/components/SystemStats.tsx
@@ -146,7 +146,7 @@ export const SystemStats: React.FC<SystemStatsProps> = ({ variant = "info", show
       </Statistic>
       <Statistic
         name="Recovery Mode"
-        tooltip="Recovery Mode is activated when the Total Collateral Ratio (TCR) falls below 150%. When active, your Trove can be liquidated if it's collateral ratio is below the TCR. The maximum value you can lose from a liquidation is 10% of your Trove's debt. Operations are also restricted that would negatively impact the TCR."
+        tooltip="Recovery Mode is activated when the Total Collateral Ratio (TCR) falls below 150%. When active, your Trove can be liquidated if it's collateral ratio is below the TCR. The maximum collateral you can lose from liquidation is capped at 110% of your Trove's debt. Operations are also restricted that would negatively impact the TCR."
       >
         {total.collateralRatioIsBelowCritical(price) ? <Box color="danger">Yes</Box> : "No"}
       </Statistic>

--- a/packages/dev-frontend/src/components/Trove/CollateralRatio.tsx
+++ b/packages/dev-frontend/src/components/Trove/CollateralRatio.tsx
@@ -1,18 +1,13 @@
 import React from "react";
 import { Flex, Box, Card } from "theme-ui";
 
-import {
-  CRITICAL_COLLATERAL_RATIO,
-  Decimal,
-  Difference,
-  MINIMUM_COLLATERAL_RATIO,
-  Percent
-} from "@liquity/lib-base";
+import { CRITICAL_COLLATERAL_RATIO, Decimal, Difference, Percent } from "@liquity/lib-base";
 
 import { Icon } from "../Icon";
 
 import { StaticRow } from "./Editor";
 import { InfoIcon } from "../InfoIcon";
+import { ActionDescription } from "../ActionDescription";
 
 type CollateralRatioProps = {
   value?: Decimal;
@@ -22,48 +17,54 @@ type CollateralRatioProps = {
 export const CollateralRatio: React.FC<CollateralRatioProps> = ({ value, change }) => {
   const collateralRatioPct = new Percent(value ?? { toString: () => "N/A" });
   const changePct = change && new Percent(change);
-
   return (
-    <Flex>
-      <Box sx={{ mt: [2, 0], ml: 3, mr: -2, fontSize: "24px" }}>
-        <Icon name="heartbeat" />
-      </Box>
+    <>
+      <Flex>
+        <Box sx={{ mt: [2, 0], ml: 3, mr: -2, fontSize: "24px" }}>
+          <Icon name="heartbeat" />
+        </Box>
 
-      <StaticRow
-        label="Collateral ratio"
-        inputId="trove-collateral-ratio"
-        amount={collateralRatioPct.prettify()}
-        color={
-          value?.gt(CRITICAL_COLLATERAL_RATIO)
-            ? "success"
-            : value?.gt(MINIMUM_COLLATERAL_RATIO)
-            ? "warning"
-            : value?.lte(MINIMUM_COLLATERAL_RATIO)
-            ? "danger"
-            : "muted"
-        }
-        pendingAmount={
-          change?.positive?.absoluteValue?.gt(10)
-            ? "++"
-            : change?.negative?.absoluteValue?.gt(10)
-            ? "--"
-            : changePct?.nonZeroish(2)?.prettify()
-        }
-        pendingColor={change?.positive ? "success" : "danger"}
-        infoIcon={
-          <InfoIcon
-            tooltip={
-              <Card variant="tooltip" sx={{ width: "220px" }}>
-                The ratio between the dollar value of the collateral and the debt (in LUSD) you are
-                depositing. While the Minimum Collateral Ratio is 110% during normal operation, it is
-                recommended to keep the Collateral Ratio always above 150% to avoid liquidation under
-                Recovery Mode. A Collateral Ratio above 200% or 250% is recommended for additional
-                safety.
-              </Card>
-            }
-          />
-        }
-      />
-    </Flex>
+        <StaticRow
+          label="Collateral ratio"
+          inputId="trove-collateral-ratio"
+          amount={collateralRatioPct.prettify()}
+          color={
+            value?.gt(CRITICAL_COLLATERAL_RATIO)
+              ? "success"
+              : value?.gt(1.2)
+              ? "warning"
+              : value?.lte(1.2)
+              ? "danger"
+              : "muted"
+          }
+          pendingAmount={
+            change?.positive?.absoluteValue?.gt(10)
+              ? "++"
+              : change?.negative?.absoluteValue?.gt(10)
+              ? "--"
+              : changePct?.nonZeroish(2)?.prettify()
+          }
+          pendingColor={change?.positive ? "success" : "danger"}
+          infoIcon={
+            <InfoIcon
+              tooltip={
+                <Card variant="tooltip" sx={{ width: "220px" }}>
+                  The ratio between the dollar value of the collateral and the debt (in LUSD) you are
+                  depositing. While the Minimum Collateral Ratio is 110% during normal operation, it
+                  is recommended to keep the Collateral Ratio always above 150% to avoid liquidation
+                  under Recovery Mode. A Collateral Ratio above 200% or 250% is recommended for
+                  additional safety.
+                </Card>
+              }
+            />
+          }
+        />
+      </Flex>
+      {value?.lt(1.5) && (
+        <ActionDescription>
+          Keeping your CR above 150% can help avoid liquidation under Recovery Mode.
+        </ActionDescription>
+      )}
+    </>
   );
 };


### PR DESCRIPTION
- red font when CR is 120% or less
- add always visible Recovery Mode stat (with tooltip for extra info)
- add information box to Trove panel which explains that a CR above 150% is better for avoiding liquidation