### PR TITLE
feat!: have only one Trove/StabilityDeposit per User

### DIFF
--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -54,17 +54,14 @@ type User @entity {
   "User's Ethereum address as a hex-string"
   id: ID!
 
-  currentTrove: Trove
-  troveCount: Int!
+  trove: Trove
+  stabilityDeposit: StabilityDeposit
 
-  currentStabilityDeposit: StabilityDeposit
-  stabilityDepositCount: Int!
-
-  troves: [Trove!]! @derivedFrom(field: "owner")
-  stabilityDeposits: [StabilityDeposit!]! @derivedFrom(field: "owner")
-  liquidations: [Liquidation!]! @derivedFrom(field: "liquidator")
   collSurplus: BigDecimal!
   collSurplusChanges: [CollSurplusChange!]! @derivedFrom(field: "user")
+
+  liquidations: [Liquidation!]! @derivedFrom(field: "liquidator")
+  redemptions: [Redemption!]! @derivedFrom(field: "redeemer")
 }
 
 enum TroveStatus {

--- a/packages/subgraph/src/entities/Global.ts
+++ b/packages/subgraph/src/entities/Global.ts
@@ -96,6 +96,14 @@ export function increaseNumberOfLiquidatedTroves(): void {
   global.save();
 }
 
+export function decreaseNumberOfLiquidatedTroves(): void {
+  let global = getGlobal();
+
+  global.numberOfLiquidatedTroves--;
+  global.numberOfOpenTroves++;
+  global.save();
+}
+
 export function increaseNumberOfRedeemedTroves(): void {
   let global = getGlobal();
 
@@ -104,10 +112,26 @@ export function increaseNumberOfRedeemedTroves(): void {
   global.save();
 }
 
+export function decreaseNumberOfRedeemedTroves(): void {
+  let global = getGlobal();
+
+  global.numberOfRedeemedTroves--;
+  global.numberOfOpenTroves++;
+  global.save();
+}
+
 export function increaseNumberOfTrovesClosedByOwner(): void {
   let global = getGlobal();
 
   global.numberOfTrovesClosedByOwner++;
   global.numberOfOpenTroves--;
+  global.save();
+}
+
+export function decreaseNumberOfTrovesClosedByOwner(): void {
+  let global = getGlobal();
+
+  global.numberOfTrovesClosedByOwner--;
+  global.numberOfOpenTroves++;
   global.save();
 }

--- a/packages/subgraph/src/entities/User.ts
+++ b/packages/subgraph/src/entities/User.ts
@@ -15,8 +15,6 @@ export function getUser(_user: Address): User {
   } else {
     let newUser = new User(id);
 
-    newUser.troveCount = 0;
-    newUser.stabilityDepositCount = 0;
     newUser.collSurplus = DECIMAL_ZERO;
     newUser.save();
 
@@ -40,7 +38,7 @@ function finishCollSurplusChange(stabilityDepositChange: CollSurplusChange): voi
 export function updateUserClaimColl(
   event: ethereum.Event,
   _borrower: Address,
-  _collSurplus: BigInt,
+  _collSurplus: BigInt
 ): void {
   let user = getUser(_borrower);
   let newCollSurplus = decimalize(_collSurplus);
@@ -54,7 +52,8 @@ export function updateUserClaimColl(
 
   collSurplusChange.collSurplusBefore = user.collSurplus;
   collSurplusChange.collSurplusAfter = newCollSurplus;
-  collSurplusChange.collSurplusChange = collSurplusChange.collSurplusAfter - collSurplusChange.collSurplusBefore;
+  collSurplusChange.collSurplusChange =
+    collSurplusChange.collSurplusAfter - collSurplusChange.collSurplusBefore;
 
   updateSystemStateByCollSurplusChange(collSurplusChange);
   finishCollSurplusChange(collSurplusChange);

--- a/packages/subgraph/subgraph.yaml
+++ b/packages/subgraph/subgraph.yaml
@@ -6,7 +6,7 @@ schema:
 dataSources:
   - name: TroveManager
     kind: ethereum/contract
-    network: ropsten
+    network: mainnet
     source:
       #address: "0x56fcdA0436E5C7a33ee5bfe292f11AC66429Eb5c"
       address: "0x6645E03DA2a711f780af7cCE1019Cb9a9135C898"
@@ -52,7 +52,7 @@ dataSources:
 templates:
   - name: BorrowerOperations
     kind: ethereum/contract
-    network: ropsten
+    network: mainnet
     source:
       abi: BorrowerOperations
     mapping:
@@ -80,7 +80,7 @@ templates:
           handler: handleTroveUpdated
   - name: StabilityPool
     kind: ethereum/contract
-    network: ropsten
+    network: mainnet
     source:
       abi: StabilityPool
     mapping:
@@ -108,7 +108,7 @@ templates:
           handler: handleETHGainWithdrawn
   - name: CollSurplusPool
     kind: ethereum/contract
-    network: ropsten
+    network: mainnet
     source:
       abi: CollSurplusPool
     mapping:


### PR DESCRIPTION
Previously, we would create a new Trove entity whenever a user called openTrove() after a closeTrove() or a liquidation/redemption. This would make it more complicated to reconstruct a "unified" Trove history, because the frontend would have to stitch together the histories of multiple Trove entities.

Let's change this so the existing Trove entity is reused when the user reopens their Trove.

Same for StabilityDeposits: we would consider the deposit "closed" when its LUSD balance would fall to 0, and create a new entity upon the next deposit event. Let's just reuse the existing entity instead.