### PR TITLE
devui: allow user to claim gains after unstaking UNI LP

### DIFF
--- a/packages/dev-frontend/src/components/Farm/context/FarmViewProvider.tsx
+++ b/packages/dev-frontend/src/components/Farm/context/FarmViewProvider.tsx
@@ -12,24 +12,38 @@ const transition = (view: FarmView, event: FarmEvent): FarmView => {
 
 const getInitialView = (
   liquidityMiningStake: Decimal,
-  remainingLiquidityMiningLQTYReward: Decimal
+  remainingLiquidityMiningLQTYReward: Decimal,
+  liquidityMiningLQTYReward: Decimal
 ): FarmView => {
   if (remainingLiquidityMiningLQTYReward.isZero) return "DISABLED";
-  if (liquidityMiningStake.isZero) return "INACTIVE";
+  if (liquidityMiningStake.isZero && liquidityMiningLQTYReward.isZero) return "INACTIVE";
   return "ACTIVE";
 };
 
 const selector = ({
   liquidityMiningStake,
-  remainingLiquidityMiningLQTYReward
-}: LiquityStoreState) => ({ liquidityMiningStake, remainingLiquidityMiningLQTYReward });
+  remainingLiquidityMiningLQTYReward,
+  liquidityMiningLQTYReward
+}: LiquityStoreState) => ({
+  liquidityMiningStake,
+  remainingLiquidityMiningLQTYReward,
+  liquidityMiningLQTYReward
+});
 
 export const FarmViewProvider: React.FC = props => {
   const { children } = props;
-  const { liquidityMiningStake, remainingLiquidityMiningLQTYReward } = useLiquitySelector(selector);
+  const {
+    liquidityMiningStake,
+    remainingLiquidityMiningLQTYReward,
+    liquidityMiningLQTYReward
+  } = useLiquitySelector(selector);
 
   const [view, setView] = useState<FarmView>(
-    getInitialView(liquidityMiningStake, remainingLiquidityMiningLQTYReward)
+    getInitialView(
+      liquidityMiningStake,
+      remainingLiquidityMiningLQTYReward,
+      liquidityMiningLQTYReward
+    )
   );
   const viewRef = useRef<FarmView>(view);
 
@@ -50,10 +64,12 @@ export const FarmViewProvider: React.FC = props => {
   }, [view]);
 
   useEffect(() => {
-    if (liquidityMiningStake.isZero) {
+    if (liquidityMiningStake.isZero && liquidityMiningLQTYReward.isZero) {
       dispatchEvent("UNSTAKE_AND_CLAIM_CONFIRMED");
+    } else if (liquidityMiningStake.isZero && !liquidityMiningLQTYReward.isZero) {
+      dispatchEvent("UNSTAKE_CONFIRMED");
     }
-  }, [liquidityMiningStake.isZero, dispatchEvent]);
+  }, [liquidityMiningStake.isZero, liquidityMiningLQTYReward.isZero, dispatchEvent]);
 
   const provider = {
     view,

--- a/packages/dev-frontend/src/components/Farm/context/transitions.ts
+++ b/packages/dev-frontend/src/components/Farm/context/transitions.ts
@@ -12,6 +12,7 @@ type CancelPressedEvent = "CANCEL_PRESSED";
 type StakeApprovedEvent = "STAKE_APPROVED";
 type StakeConfirmedEvent = "STAKE_CONFIRMED";
 type ClaimRewardConfirmedEvent = "CLAIM_REWARD_CONFIRMED";
+type UnstakeConfirmedEvent = "UNSTAKE_CONFIRMED";
 type UnstakeAndClaimConfirmedEvent = "UNSTAKE_AND_CLAIM_CONFIRMED";
 
 export type FarmEvent =
@@ -21,6 +22,7 @@ export type FarmEvent =
   | StakeApprovedEvent
   | StakeConfirmedEvent
   | ClaimRewardConfirmedEvent
+  | UnstakeConfirmedEvent
   | UnstakeAndClaimConfirmedEvent;
 
 type FarmEventTransitions = Record<FarmView, Partial<Record<FarmEvent, FarmView>>>;
@@ -42,7 +44,8 @@ export const transitions: FarmEventTransitions = {
   ADJUSTING: {
     CANCEL_PRESSED: "ACTIVE",
     STAKE_CONFIRMED: "ACTIVE",
-    STAKE_APPROVED: "ADJUSTING"
+    STAKE_APPROVED: "ADJUSTING",
+    UNSTAKE_CONFIRMED: "ACTIVE"
   },
   DISABLED: {
     CLAIM_REWARD_CONFIRMED: "DISABLED",

--- a/packages/dev-frontend/src/components/Farm/views/Active/Active.tsx
+++ b/packages/dev-frontend/src/components/Farm/views/Active/Active.tsx
@@ -42,6 +42,7 @@ export const Active: React.FC = () => {
     transactionState.type === "waitingForConfirmation";
 
   const poolShare = liquidityMiningStake.mulDiv(100, totalStakedUniTokens);
+  const hasStakeAndRewards = !liquidityMiningStake.isZero && !liquidityMiningLQTYReward.isZero;
 
   return (
     <Card>
@@ -86,15 +87,16 @@ export const Active: React.FC = () => {
         </Box>
 
         <Flex variant="layout.actions">
-          <Button variant="outline" onClick={handleAdjustPressed}>
+          <Button
+            variant={!liquidityMiningLQTYReward.isZero ? "outline" : "primary"}
+            onClick={handleAdjustPressed}
+          >
             <Icon name="pen" size="sm" />
             &nbsp;Adjust
           </Button>
-          <ClaimReward />
+          {!liquidityMiningLQTYReward.isZero && <ClaimReward />}
         </Flex>
-        <Flex>
-          <UnstakeAndClaim />
-        </Flex>
+        <Flex>{hasStakeAndRewards && <UnstakeAndClaim />}</Flex>
       </Box>
       {isTransactionPending && <LoadingOverlay />}
     </Card>


### PR DESCRIPTION
Currently a user can reduce their UNI LP to 0, which the UI then incorrectly assumes means there's no rewards to be claimed.