### PR TITLE
devui: choose borrow amount when opening trove and net debt when adjusting a trove

### DIFF
--- a/packages/dev-frontend/src/App.test.tsx
+++ b/packages/dev-frontend/src/App.test.tsx
@@ -21,8 +21,8 @@ test("there's no smoke", async () => {
   fireEvent.click(getByText(/open trove/i));
   fireEvent.click(getByLabelText(/collateral/i));
   fireEvent.change(getByLabelText(/^collateral$/i), { target: { value: `${trove.collateral}` } });
-  fireEvent.click(getByLabelText(/^debt$/i));
-  fireEvent.change(getByLabelText(/^debt$/i), { target: { value: `${trove.debt}` } });
+  fireEvent.click(getByLabelText(/^borrow$/i));
+  fireEvent.change(getByLabelText(/^borrow$/i), { target: { value: `${trove.debt}` } });
 
   const confirmButton = getAllByText(/confirm/i)[0];
   fireEvent.click(confirmButton);

--- a/packages/dev-frontend/src/components/Trove/Adjusting.tsx
+++ b/packages/dev-frontend/src/components/Trove/Adjusting.tsx
@@ -1,0 +1,227 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { Flex, Button, Box, Card, Heading } from "theme-ui";
+import {
+  LiquityStoreState,
+  Decimal,
+  Trove,
+  LUSD_LIQUIDATION_RESERVE,
+  Percent,
+  Difference
+} from "@liquity/lib-base";
+import { useLiquitySelector } from "@liquity/lib-react";
+import { ActionDescription } from "../ActionDescription";
+import { useMyTransactionState } from "../Transaction";
+import { TroveAction } from "./TroveAction";
+import { useTroveView } from "./context/TroveViewContext";
+import { COIN } from "../../strings";
+import { Icon } from "../Icon";
+import { InfoIcon } from "../InfoIcon";
+import { LoadingOverlay } from "../LoadingOverlay";
+import { CollateralRatio } from "./CollateralRatio";
+import { EditableRow, StaticRow } from "./Editor";
+import {
+  selectForTroveChangeValidation,
+  validateTroveChange
+} from "./validation/validateTroveChange";
+
+const selector = (state: LiquityStoreState) => {
+  const { trove, fees, price, accountBalance } = state;
+  return {
+    trove,
+    fees,
+    price,
+    accountBalance,
+    validationContext: selectForTroveChangeValidation(state)
+  };
+};
+
+const TRANSACTION_ID = "trove-adjustment";
+const GAS_ROOM_ETH = Decimal.from(0.1);
+
+const feeFrom = (original: Trove, edited: Trove, borrowingRate: Decimal): Decimal => {
+  const change = original.whatChanged(edited, borrowingRate);
+
+  if (change && change.type !== "invalidCreation" && change.params.borrowLUSD) {
+    return change.params.borrowLUSD.mul(borrowingRate);
+  } else {
+    return Decimal.ZERO;
+  }
+};
+
+export const Adjusting: React.FC = () => {
+  const { dispatchEvent } = useTroveView();
+  const { trove, fees, price, accountBalance, validationContext } = useLiquitySelector(selector);
+  const borrowingRate = fees.borrowingRate();
+  const editingState = useState<string>();
+  const originalNetDebt = trove.debt.sub(LUSD_LIQUIDATION_RESERVE);
+
+  const [collateral, setCollateral] = useState<Decimal>(trove.collateral);
+  const [netDebt, setNetDebt] = useState<Decimal>(originalNetDebt);
+  const isDirty = !collateral.eq(trove.collateral) || !netDebt.eq(originalNetDebt);
+  const isDebtIncrease = netDebt.gt(originalNetDebt);
+  const debtIncreaseAmount = isDebtIncrease ? netDebt.sub(originalNetDebt) : Decimal.ZERO;
+
+  const fee = isDebtIncrease
+    ? feeFrom(trove, new Trove(trove.collateral, trove.debt.add(debtIncreaseAmount)), borrowingRate)
+    : Decimal.ZERO;
+  const totalDebt = netDebt.add(LUSD_LIQUIDATION_RESERVE).add(fee);
+  const maxBorrowingRate = borrowingRate.add(0.005);
+  const updatedTrove = isDirty ? new Trove(collateral, totalDebt) : trove;
+  const feePct = new Percent(borrowingRate);
+  const maxEth = accountBalance.gt(GAS_ROOM_ETH) ? accountBalance.sub(GAS_ROOM_ETH) : Decimal.ZERO;
+  const maxCollateral = collateral.add(maxEth);
+  const collateralMaxedOut = collateral.eq(maxCollateral);
+  const collateralRatio =
+    !collateral.isZero && !netDebt.isZero ? updatedTrove.collateralRatio(price) : undefined;
+  const collateralRatioChange = Difference.between(collateralRatio, trove.collateralRatio(price));
+
+  const [troveChange, description] = validateTroveChange(
+    trove,
+    updatedTrove,
+    borrowingRate,
+    validationContext
+  );
+
+  const transactionState = useMyTransactionState(TRANSACTION_ID);
+  const isTransactionPending =
+    transactionState.type === "waitingForApproval" ||
+    transactionState.type === "waitingForConfirmation";
+
+  const handleCancelPressed = useCallback(() => {
+    dispatchEvent("CANCEL_ADJUST_TROVE_PRESSED");
+  }, [dispatchEvent]);
+
+  const reset = useCallback(() => {
+    setCollateral(trove.collateral);
+    setNetDebt(originalNetDebt);
+  }, [trove.collateral, originalNetDebt]);
+
+  useEffect(() => {
+    if (transactionState.type === "confirmedOneShot") {
+      dispatchEvent("TROVE_ADJUSTED");
+    }
+  }, [transactionState.type, dispatchEvent]);
+
+  return (
+    <Card>
+      <Heading>
+        Trove
+        {isDirty && !isTransactionPending && (
+          <Button variant="titleIcon" sx={{ ":enabled:hover": { color: "danger" } }} onClick={reset}>
+            <Icon name="history" size="lg" />
+          </Button>
+        )}
+      </Heading>
+
+      <Box sx={{ p: [2, 3] }}>
+        <EditableRow
+          label="Collateral"
+          inputId="trove-collateral"
+          amount={collateral.prettify(4)}
+          maxAmount={maxCollateral.toString()}
+          maxedOut={collateralMaxedOut}
+          editingState={editingState}
+          unit="ETH"
+          editedAmount={collateral.toString(4)}
+          setEditedAmount={(amount: string) => setCollateral(Decimal.from(amount))}
+        />
+
+        <EditableRow
+          label="Net debt"
+          inputId="trove-net-debt-amount"
+          amount={netDebt.prettify()}
+          unit={COIN}
+          editingState={editingState}
+          editedAmount={netDebt.toString(2)}
+          setEditedAmount={(amount: string) => setNetDebt(Decimal.from(amount))}
+        />
+
+        <StaticRow
+          label="Liquidation Reserve"
+          inputId="trove-liquidation-reserve"
+          amount={`${LUSD_LIQUIDATION_RESERVE}`}
+          unit={COIN}
+          infoIcon={
+            <InfoIcon
+              tooltip={
+                <Card variant="tooltip" sx={{ width: "200px" }}>
+                  An amount set aside to cover the liquidator’s gas costs if your Trove needs to be
+                  liquidated. The amount increases your debt and is refunded if you close your Trove
+                  by fully paying off its net debt.
+                </Card>
+              }
+            />
+          }
+        />
+
+        <StaticRow
+          label="Borrowing Fee"
+          inputId="trove-borrowing-fee"
+          amount={fee.prettify(2)}
+          pendingAmount={feePct.toString(2)}
+          unit={COIN}
+          infoIcon={
+            <InfoIcon
+              tooltip={
+                <Card variant="tooltip" sx={{ width: "240px" }}>
+                  This amount is deducted from the borrowed amount as a one-time fee. There are no
+                  recurring fees for borrowing, which is thus interest-free.
+                </Card>
+              }
+            />
+          }
+        />
+
+        <StaticRow
+          label="Total debt"
+          inputId="trove-total-debt"
+          amount={totalDebt.prettify(2)}
+          unit={COIN}
+          infoIcon={
+            <InfoIcon
+              tooltip={
+                <Card variant="tooltip" sx={{ width: "240px" }}>
+                  The total amount of LUSD your Trove will hold.{" "}
+                  {isDirty && (
+                    <>
+                      You will need to repay {totalDebt.sub(LUSD_LIQUIDATION_RESERVE).prettify(2)}{" "}
+                      LUSD to reclaim your collateral ({LUSD_LIQUIDATION_RESERVE.toString()} LUSD
+                      Liquidation Reserve excluded).
+                    </>
+                  )}
+                </Card>
+              }
+            />
+          }
+        />
+
+        <CollateralRatio value={collateralRatio} change={collateralRatioChange} />
+
+        {description ?? (
+          <ActionDescription>
+            Adjust your Trove by modifying its collateral, debt, or both.
+          </ActionDescription>
+        )}
+
+        <Flex variant="layout.actions">
+          <Button variant="cancel" onClick={handleCancelPressed}>
+            Cancel
+          </Button>
+
+          {troveChange ? (
+            <TroveAction
+              transactionId={TRANSACTION_ID}
+              change={troveChange}
+              maxBorrowingRate={maxBorrowingRate}
+            >
+              Confirm
+            </TroveAction>
+          ) : (
+            <Button disabled>Confirm</Button>
+          )}
+        </Flex>
+      </Box>
+      {isTransactionPending && <LoadingOverlay />}
+    </Card>
+  );
+};

--- a/packages/dev-frontend/src/components/Trove/Opening.tsx
+++ b/packages/dev-frontend/src/components/Trove/Opening.tsx
@@ -1,0 +1,206 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { Flex, Button, Box, Card, Heading } from "theme-ui";
+
+import {
+  LiquityStoreState,
+  Decimal,
+  Trove,
+  LUSD_MINIMUM_DEBT,
+  LUSD_LIQUIDATION_RESERVE,
+  Percent
+} from "@liquity/lib-base";
+
+import { useLiquitySelector } from "@liquity/lib-react";
+
+import { ActionDescription } from "../ActionDescription";
+import { useMyTransactionState } from "../Transaction";
+
+import { TroveAction } from "./TroveAction";
+import { useTroveView } from "./context/TroveViewContext";
+
+import { COIN } from "../../strings";
+import { Icon } from "../Icon";
+import { InfoIcon } from "../InfoIcon";
+import { LoadingOverlay } from "../LoadingOverlay";
+import { CollateralRatio } from "./CollateralRatio";
+import { EditableRow, StaticRow } from "./Editor";
+import {
+  selectForTroveChangeValidation,
+  validateTroveChange
+} from "./validation/validateTroveChange";
+
+const selector = (state: LiquityStoreState) => {
+  const { fees, price } = state;
+  return {
+    fees,
+    price,
+    validationContext: selectForTroveChangeValidation(state)
+  };
+};
+const EMPTY_TROVE = new Trove(Decimal.ZERO, Decimal.ZERO);
+const TINY_EXTRA_LUSD_TO_ALLOW_MINIMUM = 0.0001;
+const TRANSACTION_ID = "trove-creation";
+
+export const Opening: React.FC = () => {
+  const { dispatchEvent } = useTroveView();
+  const { fees, price, validationContext } = useLiquitySelector(selector);
+  const borrowingRate = fees.borrowingRate();
+  const editingState = useState<string>();
+
+  const minimumBorrowAmount = Decimal.from(LUSD_MINIMUM_DEBT.sub(LUSD_LIQUIDATION_RESERVE))
+    .div(Decimal.from(1).add(borrowingRate))
+    .add(TINY_EXTRA_LUSD_TO_ALLOW_MINIMUM);
+  const [collateral, setCollateral] = useState<Decimal>(Decimal.ZERO);
+  const [borrowAmount, setBorrowAmount] = useState<Decimal>(Decimal.ZERO);
+
+  const maxBorrowingRate = borrowingRate.add(0.005);
+
+  const fee = borrowAmount.mul(borrowingRate);
+  const feePct = new Percent(borrowingRate);
+  const totalDebt = borrowAmount.add(LUSD_LIQUIDATION_RESERVE).add(fee);
+  const isDirty = !collateral.isZero || !borrowAmount.isZero;
+  const trove = isDirty ? new Trove(collateral, totalDebt) : EMPTY_TROVE;
+
+  const [troveChange, description] = validateTroveChange(
+    EMPTY_TROVE,
+    trove,
+    borrowingRate,
+    validationContext
+  );
+
+  const collateralRatio =
+    !collateral.isZero && !borrowAmount.isZero ? trove.collateralRatio(price) : undefined;
+
+  const transactionState = useMyTransactionState(TRANSACTION_ID);
+  const isTransactionPending =
+    transactionState.type === "waitingForApproval" ||
+    transactionState.type === "waitingForConfirmation";
+  const handleCancelPressed = () => dispatchEvent("CANCEL_ADJUST_TROVE_PRESSED");
+
+  const reset = useCallback(() => {
+    setCollateral(Decimal.ZERO);
+    setBorrowAmount(Decimal.ZERO);
+  }, []);
+
+  useEffect(() => {
+    if (!collateral.isZero && borrowAmount.isZero) {
+      setBorrowAmount(minimumBorrowAmount);
+    }
+  }, [collateral, borrowAmount, minimumBorrowAmount]);
+
+  return (
+    <Card>
+      <Heading>
+        Trove
+        {isDirty && !isTransactionPending && (
+          <Button variant="titleIcon" sx={{ ":enabled:hover": { color: "danger" } }} onClick={reset}>
+            <Icon name="history" size="lg" />
+          </Button>
+        )}
+      </Heading>
+
+      <Box sx={{ p: [2, 3] }}>
+        <EditableRow
+          label="Collateral"
+          inputId="trove-collateral"
+          amount={collateral.prettify(4)}
+          // maxAmount={maxCollateral.toString()}
+          // maxedOut={collateralMaxedOut}
+          editingState={editingState}
+          unit="ETH"
+          editedAmount={collateral.toString(4)}
+          setEditedAmount={(amount: string) => setCollateral(Decimal.from(amount))}
+        />
+
+        <EditableRow
+          label="Borrow"
+          inputId="trove-borrow-amount"
+          amount={borrowAmount.prettify()}
+          unit={COIN}
+          editingState={editingState}
+          editedAmount={borrowAmount.toString(2)}
+          setEditedAmount={(amount: string) => setBorrowAmount(Decimal.from(amount))}
+        />
+
+        <StaticRow
+          label="Liquidation Reserve"
+          inputId="trove-liquidation-reserve"
+          amount={`${LUSD_LIQUIDATION_RESERVE}`}
+          unit={COIN}
+          infoIcon={
+            <InfoIcon
+              tooltip={
+                <Card variant="tooltip" sx={{ width: "200px" }}>
+                  An amount set aside to cover the liquidator’s gas costs if your Trove needs to be
+                  liquidated. The amount increases your debt and is refunded if you close your Trove
+                  by fully paying off its net debt.
+                </Card>
+              }
+            />
+          }
+        />
+
+        <StaticRow
+          label="Borrowing Fee"
+          inputId="trove-borrowing-fee"
+          amount={fee.prettify(2)}
+          pendingAmount={feePct.toString(2)}
+          unit={COIN}
+          infoIcon={
+            <InfoIcon
+              tooltip={
+                <Card variant="tooltip" sx={{ width: "240px" }}>
+                  This amount is deducted from the borrowed amount as a one-time fee. There are no
+                  recurring fees for borrowing, which is thus interest-free.
+                </Card>
+              }
+            />
+          }
+        />
+
+        <StaticRow
+          label="Total debt"
+          inputId="trove-total-debt"
+          amount={totalDebt.prettify(2)}
+          unit={COIN}
+          infoIcon={
+            <InfoIcon
+              tooltip={
+                <Card variant="tooltip" sx={{ width: "240px" }}>
+                  TODO
+                </Card>
+              }
+            />
+          }
+        />
+
+        <CollateralRatio value={collateralRatio} />
+
+        {description ?? (
+          <ActionDescription>
+            Start by entering the amount of ETH you'd like to deposit as collateral.
+          </ActionDescription>
+        )}
+
+        <Flex variant="layout.actions">
+          <Button variant="cancel" onClick={handleCancelPressed}>
+            Cancel
+          </Button>
+
+          {troveChange ? (
+            <TroveAction
+              transactionId={TRANSACTION_ID}
+              change={troveChange}
+              maxBorrowingRate={maxBorrowingRate}
+            >
+              Confirm
+            </TroveAction>
+          ) : (
+            <Button disabled>Confirm</Button>
+          )}
+        </Flex>
+      </Box>
+      {isTransactionPending && <LoadingOverlay />}
+    </Card>
+  );
+};

--- a/packages/dev-frontend/src/components/Trove/Trove.tsx
+++ b/packages/dev-frontend/src/components/Trove/Trove.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { TroveManager } from "./TroveManager";
 import { ReadOnlyTrove } from "./ReadOnlyTrove";
 import { NoTrove } from "./NoTrove";
+import { Opening } from "./Opening";
 import { RedeemedTrove } from "./RedeemedTrove";
 import { useTroveView } from "./context/TroveViewContext";
 import { LiquidatedTrove } from "./LiquidatedTrove";
@@ -22,7 +23,7 @@ export const Trove: React.FC = props => {
       return <TroveManager {...props} collateral={Decimal.ZERO} debt={Decimal.ZERO} />;
     }
     case "OPENING": {
-      return <TroveManager {...props} />;
+      return <Opening {...props} />;
     }
     case "LIQUIDATED": {
       return <LiquidatedTrove {...props} />;

--- a/packages/dev-frontend/src/components/Trove/Trove.tsx
+++ b/packages/dev-frontend/src/components/Trove/Trove.tsx
@@ -3,6 +3,7 @@ import { TroveManager } from "./TroveManager";
 import { ReadOnlyTrove } from "./ReadOnlyTrove";
 import { NoTrove } from "./NoTrove";
 import { Opening } from "./Opening";
+import { Adjusting } from "./Adjusting";
 import { RedeemedTrove } from "./RedeemedTrove";
 import { useTroveView } from "./context/TroveViewContext";
 import { LiquidatedTrove } from "./LiquidatedTrove";
@@ -17,7 +18,7 @@ export const Trove: React.FC = props => {
       return <ReadOnlyTrove {...props} />;
     }
     case "ADJUSTING": {
-      return <TroveManager {...props} />;
+      return <Adjusting {...props} />;
     }
     case "CLOSING": {
       return <TroveManager {...props} collateral={Decimal.ZERO} debt={Decimal.ZERO} />;

--- a/packages/dev-frontend/src/components/Trove/TroveEditor.tsx
+++ b/packages/dev-frontend/src/components/Trove/TroveEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { Heading, Box, Card, Button } from "theme-ui";
 
 import {
@@ -15,12 +15,10 @@ import { useLiquitySelector } from "@liquity/lib-react";
 import { COIN } from "../../strings";
 
 import { Icon } from "../Icon";
-import { EditableRow, StaticRow } from "./Editor";
+import { StaticRow } from "./Editor";
 import { LoadingOverlay } from "../LoadingOverlay";
 import { CollateralRatio } from "./CollateralRatio";
 import { InfoIcon } from "../InfoIcon";
-
-const gasRoomETH = Decimal.from(0.1);
 
 type TroveEditorProps = {
   original: Trove;
@@ -33,7 +31,7 @@ type TroveEditorProps = {
   ) => void;
 };
 
-const select = ({ price, accountBalance }: LiquityStoreState) => ({ price, accountBalance });
+const select = ({ price }: LiquityStoreState) => ({ price });
 
 export const TroveEditor: React.FC<TroveEditorProps> = ({
   children,
@@ -44,19 +42,13 @@ export const TroveEditor: React.FC<TroveEditorProps> = ({
   changePending,
   dispatch
 }) => {
-  const { price, accountBalance } = useLiquitySelector(select);
-
-  const editingState = useState<string>();
+  const { price } = useLiquitySelector(select);
 
   const feePct = new Percent(borrowingRate);
 
   const originalCollateralRatio = !original.isEmpty ? original.collateralRatio(price) : undefined;
   const collateralRatio = !edited.isEmpty ? edited.collateralRatio(price) : undefined;
   const collateralRatioChange = Difference.between(collateralRatio, originalCollateralRatio);
-
-  const maxEth = accountBalance.gt(gasRoomETH) ? accountBalance.sub(gasRoomETH) : Decimal.ZERO;
-  const maxCollateral = original.collateral.add(maxEth);
-  const collateralMaxedOut = edited.collateral.eq(maxCollateral);
 
   const dirty = !edited.equals(original);
 
@@ -76,31 +68,14 @@ export const TroveEditor: React.FC<TroveEditorProps> = ({
       </Heading>
 
       <Box sx={{ p: [2, 3] }}>
-        <EditableRow
+        <StaticRow
           label="Collateral"
           inputId="trove-collateral"
           amount={edited.collateral.prettify(4)}
-          maxAmount={maxCollateral.toString()}
-          maxedOut={collateralMaxedOut}
           unit="ETH"
-          {...{ editingState }}
-          editedAmount={edited.collateral.toString(4)}
-          setEditedAmount={(editedCollateral: string) =>
-            dispatch({ type: "setCollateral", newValue: editedCollateral })
-          }
         />
 
-        <EditableRow
-          label="Debt"
-          inputId="trove-debt"
-          amount={edited.debt.prettify()}
-          unit={COIN}
-          {...{ editingState }}
-          editedAmount={edited.debt.toString(2)}
-          setEditedAmount={(editedDebt: string) =>
-            dispatch({ type: "setDebt", newValue: editedDebt })
-          }
-        />
+        <StaticRow label="Debt" inputId="trove-debt" amount={edited.debt.prettify()} unit={COIN} />
 
         {original.isEmpty && (
           <StaticRow

--- a/packages/dev-frontend/src/components/Trove/validation/validateTroveChange.tsx
+++ b/packages/dev-frontend/src/components/Trove/validation/validateTroveChange.tsx
@@ -137,7 +137,7 @@ export const validateTroveChange = (
     return [
       undefined,
       <ErrorDescription>
-        Debt must be at least{" "}
+        Total debt must be at least{" "}
         <Amount>
           {LUSD_MINIMUM_DEBT.toString()} {COIN}
         </Amount>
@@ -173,7 +173,7 @@ const validateTroveCreation = (
   if (resultingTrove.debt.lt(LUSD_MINIMUM_DEBT)) {
     return (
       <ErrorDescription>
-        Debt must be at least{" "}
+        Total debt must be at least{" "}
         <Amount>
           {LUSD_MINIMUM_DEBT.toString()} {COIN}
         </Amount>
@@ -284,7 +284,7 @@ const validateTroveAdjustment = (
     if (resultingTrove.debt.lt(LUSD_MINIMUM_DEBT)) {
       return (
         <ErrorDescription>
-          Debt must be at least{" "}
+          Total debt must be at least{" "}
           <Amount>
             {LUSD_MINIMUM_DEBT.toString()} {COIN}
           </Amount>


### PR DESCRIPTION
- Introduce Opening view for the OPENING state
- Introduce Adjusting view for the ADJUSTING state
- Ask user for a borrow amount instead of total debt when OPENING
- Ask user for a new net debt amount instead of a total debt when ADJUSTING