### PR TITLE
devui: update min borrow amount and sync backend changes

### DIFF
--- a/packages/dev-frontend/src/components/Trove/Adjusting.tsx
+++ b/packages/dev-frontend/src/components/Trove/Adjusting.tsx
@@ -99,7 +99,7 @@ export const Adjusting: React.FC = () => {
       setNetDebt(nextNetDebt);
     }
     previousTrove.current = trove;
-  }, [borrowingRate, trove, collateral, netDebt]);
+  }, [trove, collateral, netDebt]);
 
   const handleCancelPressed = useCallback(() => {
     dispatchEvent("CANCEL_ADJUST_TROVE_PRESSED");

--- a/packages/dev-frontend/src/components/Trove/Adjusting.tsx
+++ b/packages/dev-frontend/src/components/Trove/Adjusting.tsx
@@ -50,22 +50,30 @@ const feeFrom = (original: Trove, edited: Trove, borrowingRate: Decimal): Decima
 
 const applyUnsavedCollateralChanges = (unsavedChanges: Difference, trove: Trove) => {
   if (unsavedChanges.absoluteValue) {
-    return unsavedChanges.positive
-      ? trove.collateral.add(unsavedChanges.absoluteValue)
-      : unsavedChanges.negative
-      ? trove.collateral.sub(unsavedChanges.absoluteValue)
-      : trove.collateral;
+    if (unsavedChanges.positive) {
+      return trove.collateral.add(unsavedChanges.absoluteValue);
+    }
+    if (unsavedChanges.negative) {
+      if (unsavedChanges.absoluteValue.lt(trove.collateral)) {
+        return trove.collateral.sub(unsavedChanges.absoluteValue);
+      }
+    }
+    return trove.collateral;
   }
   return trove.collateral;
 };
 
 const applyUnsavedNetDebtChanges = (unsavedChanges: Difference, trove: Trove) => {
   if (unsavedChanges.absoluteValue) {
-    return unsavedChanges.positive
-      ? trove.netDebt.add(unsavedChanges.absoluteValue)
-      : unsavedChanges.negative
-      ? trove.netDebt.sub(unsavedChanges.absoluteValue)
-      : trove.netDebt;
+    if (unsavedChanges.positive) {
+      return trove.netDebt.add(unsavedChanges.absoluteValue);
+    }
+    if (unsavedChanges.negative) {
+      if (unsavedChanges.absoluteValue.lt(trove.netDebt)) {
+        return trove.netDebt.sub(unsavedChanges.absoluteValue);
+      }
+    }
+    return trove.netDebt;
   }
   return trove.netDebt;
 };

--- a/packages/dev-frontend/src/components/Trove/Opening.tsx
+++ b/packages/dev-frontend/src/components/Trove/Opening.tsx
@@ -4,7 +4,6 @@ import {
   LiquityStoreState,
   Decimal,
   Trove,
-  LUSD_MINIMUM_DEBT,
   LUSD_LIQUIDATION_RESERVE,
   Percent
 } from "@liquity/lib-base";
@@ -35,9 +34,9 @@ const selector = (state: LiquityStoreState) => {
 };
 
 const EMPTY_TROVE = new Trove(Decimal.ZERO, Decimal.ZERO);
-const TINY_EXTRA_LUSD_TO_ALLOW_MINIMUM = 0.0001;
 const TRANSACTION_ID = "trove-creation";
 const GAS_ROOM_ETH = Decimal.from(0.1);
+const MIN_BORROW_AMOUNT = Decimal.from(1800);
 
 export const Opening: React.FC = () => {
   const { dispatchEvent } = useTroveView();
@@ -45,9 +44,6 @@ export const Opening: React.FC = () => {
   const borrowingRate = fees.borrowingRate();
   const editingState = useState<string>();
 
-  const minimumBorrowAmount = Decimal.from(LUSD_MINIMUM_DEBT.sub(LUSD_LIQUIDATION_RESERVE))
-    .div(Decimal.from(1).add(borrowingRate))
-    .add(TINY_EXTRA_LUSD_TO_ALLOW_MINIMUM);
   const [collateral, setCollateral] = useState<Decimal>(Decimal.ZERO);
   const [borrowAmount, setBorrowAmount] = useState<Decimal>(Decimal.ZERO);
 
@@ -87,9 +83,9 @@ export const Opening: React.FC = () => {
 
   useEffect(() => {
     if (!collateral.isZero && borrowAmount.isZero) {
-      setBorrowAmount(minimumBorrowAmount);
+      setBorrowAmount(MIN_BORROW_AMOUNT);
     }
-  }, [collateral, borrowAmount, minimumBorrowAmount]);
+  }, [collateral, borrowAmount]);
 
   return (
     <Card>

--- a/packages/dev-frontend/src/components/Trove/Opening.tsx
+++ b/packages/dev-frontend/src/components/Trove/Opening.tsx
@@ -5,6 +5,7 @@ import {
   Decimal,
   Trove,
   LUSD_LIQUIDATION_RESERVE,
+  LUSD_MINIMUM_NET_DEBT,
   Percent
 } from "@liquity/lib-base";
 import { useLiquitySelector } from "@liquity/lib-react";
@@ -36,7 +37,6 @@ const selector = (state: LiquityStoreState) => {
 const EMPTY_TROVE = new Trove(Decimal.ZERO, Decimal.ZERO);
 const TRANSACTION_ID = "trove-creation";
 const GAS_ROOM_ETH = Decimal.from(0.1);
-const MIN_BORROW_AMOUNT = Decimal.from(1800);
 
 export const Opening: React.FC = () => {
   const { dispatchEvent } = useTroveView();
@@ -83,7 +83,7 @@ export const Opening: React.FC = () => {
 
   useEffect(() => {
     if (!collateral.isZero && borrowAmount.isZero) {
-      setBorrowAmount(MIN_BORROW_AMOUNT);
+      setBorrowAmount(LUSD_MINIMUM_NET_DEBT);
     }
   }, [collateral, borrowAmount]);
 

--- a/packages/dev-frontend/src/components/Trove/TroveEditor.tsx
+++ b/packages/dev-frontend/src/components/Trove/TroveEditor.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Heading, Box, Card, Button } from "theme-ui";
+import { Heading, Box, Card } from "theme-ui";
 
 import {
   Percent,
@@ -14,7 +14,6 @@ import { useLiquitySelector } from "@liquity/lib-react";
 
 import { COIN } from "../../strings";
 
-import { Icon } from "../Icon";
 import { StaticRow } from "./Editor";
 import { LoadingOverlay } from "../LoadingOverlay";
 import { CollateralRatio } from "./CollateralRatio";
@@ -39,8 +38,7 @@ export const TroveEditor: React.FC<TroveEditorProps> = ({
   edited,
   fee,
   borrowingRate,
-  changePending,
-  dispatch
+  changePending
 }) => {
   const { price } = useLiquitySelector(select);
 
@@ -50,22 +48,9 @@ export const TroveEditor: React.FC<TroveEditorProps> = ({
   const collateralRatio = !edited.isEmpty ? edited.collateralRatio(price) : undefined;
   const collateralRatioChange = Difference.between(collateralRatio, originalCollateralRatio);
 
-  const dirty = !edited.equals(original);
-
   return (
     <Card>
-      <Heading>
-        Trove
-        {dirty && !changePending && (
-          <Button
-            variant="titleIcon"
-            sx={{ ":enabled:hover": { color: "danger" } }}
-            onClick={() => dispatch({ type: "revert" })}
-          >
-            <Icon name="history" size="lg" />
-          </Button>
-        )}
-      </Heading>
+      <Heading>Trove</Heading>
 
       <Box sx={{ p: [2, 3] }}>
         <StaticRow


### PR DESCRIPTION
- Set min borrow amount to 1800 to compensate for fee decay factor
- Apply unsaved Trove adjustments to changes from the backend (e.g. debt redistribution or partial redemption)
- Handle Trove closed event (only render component if trove is `open`)