### PR TITLE
fix: eliminate bogus `TroveChange` upon capped liquidation

### DIFF
--- a/packages/subgraph/src/mappings/BorrowerOperations.ts
+++ b/packages/subgraph/src/mappings/BorrowerOperations.ts
@@ -1,6 +1,4 @@
-import { TroveManager } from "../../generated/TroveManager/TroveManager";
 import {
-  BorrowerOperations,
   TroveUpdated,
   LUSDBorrowingFeePaid
 } from "../../generated/BorrowerOperations/BorrowerOperations";
@@ -11,20 +9,13 @@ import { setBorrowingFeeOfLastTroveChange, updateTrove } from "../entities/Trove
 import { increaseTotalBorrowingFeesPaid } from "../entities/Global";
 
 export function handleTroveUpdated(event: TroveUpdated): void {
-  let borrowerOperations = BorrowerOperations.bind(event.address);
-  let troveManagerAddress = borrowerOperations.troveManager();
-  let troveManager = TroveManager.bind(troveManagerAddress);
-  let snapshots = troveManager.rewardSnapshots(event.params._borrower);
-
   updateTrove(
     event,
     getTroveOperationFromBorrowerOperation(event.params.operation),
     event.params._borrower,
     event.params._coll,
     event.params._debt,
-    event.params.stake,
-    snapshots.value0,
-    snapshots.value1
+    event.params.stake
   );
 }
 

--- a/packages/subgraph/subgraph.yaml.js
+++ b/packages/subgraph/subgraph.yaml.js
@@ -56,6 +56,8 @@ dataSources:
           handler: handleLiquidation
         - event: Redemption(uint256,uint256,uint256,uint256)
           handler: handleRedemption
+        - event: LTermsUpdated(uint256,uint256)
+          handler: handleLTermsUpdated
   - name: BorrowerOperations
     kind: ethereum/contract
     network: mainnet


### PR DESCRIPTION
The issue was introduced when capped liquidations were added to the backend.
Up until then, the `_coll` and `_debt` parameters of `TroveLiquidated` events
reflected the final state of the Trove immediately before the liquidation.

The subgraph relied on this to insert an `accrueRewards` operation in case
there have been redistributions between the last Trove adjustment and the
liquidation. However, in the case of a capped liquidation, `_coll` now reflects
the capped portion of the collateral that's liquidated, so we can no longer
rely on the event's parameters.

Instead, we should calculate the redistribution from the Trove's snapshots,
stake and the global redistribution counters.

Fixes #580.