### PR TITLE
Fix price in subgraph

### DIFF
--- a/packages/contracts/contracts/TestContracts/PriceFeedTestnet.sol
+++ b/packages/contracts/contracts/TestContracts/PriceFeedTestnet.sol
@@ -20,6 +20,9 @@ contract PriceFeedTestnet is IPriceFeed {
     }
 
     function fetchPrice() external override returns (uint256) {
+        // Fire an event just like the mainnet version would.
+        // This lets the subgraph rely on events to get the latest price even when developing locally.
+        emit LastGoodPriceUpdated(_price);
         return _price;
     }
 

--- a/packages/lib-subgraph/apollo.config.js
+++ b/packages/lib-subgraph/apollo.config.js
@@ -2,7 +2,7 @@ module.exports = {
   client: {
     service: {
       name: "liquity-subgraph",
-      url: "http://localhost:8000/subgraphs/name/liquity/subgraph"
+      url: "http://localhost:8000/subgraphs/name/liquity/liquity"
     }
   }
 };

--- a/packages/lib-subgraph/src/SubgraphLiquity.ts
+++ b/packages/lib-subgraph/src/SubgraphLiquity.ts
@@ -136,7 +136,7 @@ const troveBeforeRedistribution = new Query<
     query TroveWithoutRewards($address: ID!) {
       user(id: $address) {
         id
-        currentTrove {
+        trove {
           id
           ...TroveRawFields
         }
@@ -145,8 +145,8 @@ const troveBeforeRedistribution = new Query<
     ${troveRawFields}
   `,
   ({ data: { user } }, { address }) => {
-    if (user?.currentTrove) {
-      return troveFromRawFields(user.currentTrove);
+    if (user?.trove) {
+      return troveFromRawFields(user.trove);
     } else {
       return new TroveWithPendingRedistribution(address, "nonExistent");
     }

--- a/packages/lib-subgraph/types/Global.ts
+++ b/packages/lib-subgraph/types/Global.ts
@@ -13,7 +13,7 @@ export interface Global_global_currentSystemState {
    * Sequence number as an ID (string)
    */
   id: string;
-  price: any;
+  price: any | null;
   totalCollateral: any;
   totalDebt: any;
   tokensInStabilityPool: any;

--- a/packages/lib-subgraph/types/TroveWithoutRewards.ts
+++ b/packages/lib-subgraph/types/TroveWithoutRewards.ts
@@ -9,7 +9,7 @@ import { TroveStatus } from "./globalTypes";
 // GraphQL query operation: TroveWithoutRewards
 // ====================================================
 
-export interface TroveWithoutRewards_user_currentTrove_owner {
+export interface TroveWithoutRewards_user_trove_owner {
   __typename: "User";
   /**
    * User's Ethereum address as a hex-string
@@ -17,13 +17,13 @@ export interface TroveWithoutRewards_user_currentTrove_owner {
   id: string;
 }
 
-export interface TroveWithoutRewards_user_currentTrove {
+export interface TroveWithoutRewards_user_trove {
   __typename: "Trove";
   /**
    * Owner's ID + '-' + an incremented integer
    */
   id: string;
-  owner: TroveWithoutRewards_user_currentTrove_owner;
+  owner: TroveWithoutRewards_user_trove_owner;
   status: TroveStatus;
   rawCollateral: any;
   rawDebt: any;
@@ -44,7 +44,7 @@ export interface TroveWithoutRewards_user {
    * User's Ethereum address as a hex-string
    */
   id: string;
-  currentTrove: TroveWithoutRewards_user_currentTrove | null;
+  trove: TroveWithoutRewards_user_trove | null;
 }
 
 export interface TroveWithoutRewards {

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -2,8 +2,6 @@ type Global @entity {
   "There should be only one System entity with an ID of 'only'"
   id: ID!
 
-  priceFeedAddress: Bytes
-
   systemStateCount: Int!
   transactionCount: Int!
   changeCount: Int!
@@ -50,7 +48,7 @@ type SystemState @entity {
   "Can be used to chronologically sort SystemStates"
   sequenceNumber: Int!
 
-  price: BigDecimal!
+  price: BigDecimal
 
   totalCollateral: BigDecimal!
   totalDebt: BigDecimal!

--- a/packages/subgraph/src/calls/PriceFeed.ts
+++ b/packages/subgraph/src/calls/PriceFeed.ts
@@ -1,9 +1,0 @@
-import { Address, BigInt } from "@graphprotocol/graph-ts";
-
-import { PriceFeed } from "../../generated/TroveManager/PriceFeed";
-
-export function getPrice(priceFeedAddress: Address): BigInt {
-  let priceFeed = PriceFeed.bind(priceFeedAddress);
-
-  return priceFeed.fetchPrice();
-}

--- a/packages/subgraph/src/entities/Change.ts
+++ b/packages/subgraph/src/entities/Change.ts
@@ -4,14 +4,7 @@ import { getChangeSequenceNumber } from "./Global";
 import { getTransaction } from "./Transaction";
 import { getCurrentSystemState } from "./SystemState";
 
-export function beginChange(event: ethereum.Event): i32 {
-  // Pre-create the Transaction entity that this change will eventually refer to (if it doesn't
-  // exist yet).
-
-  // This is needed because creating a new Transaction may have the side effect of increasing the
-  // change sequence number through creating a PriceChange.
-  getTransaction(event);
-
+export function beginChange(): i32 {
   return getChangeSequenceNumber();
 }
 

--- a/packages/subgraph/src/entities/Global.ts
+++ b/packages/subgraph/src/entities/Global.ts
@@ -1,4 +1,4 @@
-import { Value, BigInt, BigDecimal, Address } from "@graphprotocol/graph-ts";
+import { Value, BigInt } from "@graphprotocol/graph-ts";
 
 import { Global, LqtyStakeChange } from "../../generated/schema";
 
@@ -70,17 +70,6 @@ export function getLiquidationSequenceNumber(): i32 {
 
 export function getRedemptionSequenceNumber(): i32 {
   return increaseCounter("redemptionCount");
-}
-
-export function updatePriceFeedAddress(priceFeedAddress: Address): void {
-  let global = getGlobal();
-
-  global.priceFeedAddress = priceFeedAddress;
-  global.save();
-}
-
-export function getPriceFeedAddress(): Address {
-  return getGlobal().priceFeedAddress as Address;
 }
 
 export function updateTotalRedistributed(L_ETH: BigInt, L_LUSDDebt: BigInt): void {

--- a/packages/subgraph/src/entities/LqtyStake.ts
+++ b/packages/subgraph/src/entities/LqtyStake.ts
@@ -9,7 +9,7 @@ import { getUser } from "./User";
 import { handleLQTYStakeChange } from "./Global";
 
 function startLQTYStakeChange(event: ethereum.Event): LqtyStakeChange {
-  let sequenceNumber = beginChange(event);
+  let sequenceNumber = beginChange();
   let stakeChange = new LqtyStakeChange(sequenceNumber.toString());
   stakeChange.issuanceGain = DECIMAL_ZERO;
   stakeChange.redemptionGain = DECIMAL_ZERO;

--- a/packages/subgraph/src/entities/StabilityDeposit.ts
+++ b/packages/subgraph/src/entities/StabilityDeposit.ts
@@ -28,7 +28,7 @@ function getStabilityDeposit(_user: Address): StabilityDeposit {
 }
 
 function createStabilityDepositChange(event: ethereum.Event): StabilityDepositChange {
-  let sequenceNumber = beginChange(event);
+  let sequenceNumber = beginChange();
   let stabilityDepositChange = new StabilityDepositChange(sequenceNumber.toString());
   initChange(stabilityDepositChange, event, sequenceNumber);
 
@@ -112,7 +112,7 @@ export function withdrawCollateralGainFromStabilityDeposit(
 
   let stabilityDeposit = getStabilityDeposit(_user) as StabilityDeposit;
   let depositLoss = decimalize(_LUSDLoss);
-  let newDepositedAmount = stabilityDeposit.depositedAmount - depositLoss;
+  let newDepositedAmount = stabilityDeposit.depositedAmount.minus(depositLoss);
 
   updateStabilityDepositByOperation(
     event,

--- a/packages/subgraph/src/entities/SystemState.ts
+++ b/packages/subgraph/src/entities/SystemState.ts
@@ -1,4 +1,4 @@
-import { ethereum, BigDecimal } from "@graphprotocol/graph-ts";
+import { ethereum, BigDecimal, BigInt } from "@graphprotocol/graph-ts";
 
 import {
   SystemState,
@@ -8,7 +8,7 @@ import {
   CollSurplusChange
 } from "../../generated/schema";
 
-import { decimalize, DECIMAL_INITIAL_PRICE, DECIMAL_ZERO, DECIMAL_ONE } from "../utils/bignumbers";
+import { decimalize, DECIMAL_ZERO, DECIMAL_ONE } from "../utils/bignumbers";
 import { calculateCollateralRatio } from "../utils/collateralRatio";
 
 import {
@@ -18,9 +18,7 @@ import {
   isRecoveryModeLiquidation
 } from "../types/TroveOperation";
 
-import { getPrice } from "../calls/PriceFeed";
-
-import { getGlobal, getSystemStateSequenceNumber, getPriceFeedAddress } from "./Global";
+import { getGlobal, getSystemStateSequenceNumber } from "./Global";
 import { beginChange, initChange, finishChange } from "./Change";
 
 export function getCurrentSystemState(): SystemState {
@@ -32,7 +30,6 @@ export function getCurrentSystemState(): SystemState {
     let newSystemState = new SystemState(sequenceNumber.toString());
 
     newSystemState.sequenceNumber = sequenceNumber;
-    newSystemState.price = DECIMAL_INITIAL_PRICE;
     newSystemState.totalCollateral = DECIMAL_ZERO;
     newSystemState.totalDebt = DECIMAL_ZERO;
     newSystemState.tokensInStabilityPool = DECIMAL_ZERO;
@@ -60,16 +57,17 @@ export function bumpSystemState(systemState: SystemState): void {
   global.save();
 }
 
-// To make sure this returns the latest price, a Transaction entity should be created for the
-// triggering event beforehand, either directly or indirectly through creating a Change entity
 export function getCurrentPrice(): BigDecimal {
   let currentSystemState = getCurrentSystemState();
 
-  return currentSystemState.price;
+  // The backend always starts with fetching the latest price, so LastGoodPriceUpdated will be
+  // the first event emitted. We can be sure that by the time we need the price, it will have been
+  // initialized.
+  return currentSystemState.price!;
 }
 
 function createPriceChange(event: ethereum.Event): PriceChange {
-  let sequenceNumber = beginChange(event);
+  let sequenceNumber = beginChange();
   let priceChange = new PriceChange(sequenceNumber.toString());
   initChange(priceChange, event, sequenceNumber);
 
@@ -82,13 +80,23 @@ function finishPriceChange(priceChange: PriceChange): void {
 }
 
 /*
- * Call the PriceFeed to get the latest price, and update the SystemState through a PriceChange
- * if it has changed.
+ * Update SystemState through a PriceChange if _lastGoodPrice is different from the last recorded
+ * price.
  */
-export function checkPrice(event: ethereum.Event): void {
+export function updatePrice(event: ethereum.Event, _lastGoodPrice: BigInt): void {
   let systemState = getCurrentSystemState();
-  let oldPrice = systemState.price;
-  let newPrice = decimalize(getPrice(getPriceFeedAddress()));
+  let oldPriceOrNull = systemState.price;
+  let newPrice = decimalize(_lastGoodPrice);
+
+  if (oldPriceOrNull == null) {
+    // On first price event, just initialize price in the current system state without creating
+    // a price change.
+    systemState.price = newPrice;
+    systemState.save();
+    return;
+  }
+
+  let oldPrice = oldPriceOrNull!;
 
   if (newPrice != oldPrice) {
     let priceChange = createPriceChange(event);
@@ -96,7 +104,7 @@ export function checkPrice(event: ethereum.Event): void {
     systemState.price = newPrice;
     bumpSystemState(systemState);
 
-    priceChange.priceChange = newPrice - oldPrice;
+    priceChange.priceChange = newPrice.minus(oldPrice);
     finishPriceChange(priceChange);
   }
 }
@@ -143,7 +151,7 @@ export function updateSystemStateByTroveChange(troveChange: TroveChange): void {
   systemState.totalCollateralRatio = calculateCollateralRatio(
     systemState.totalCollateral,
     systemState.totalDebt,
-    systemState.price
+    systemState.price! // A trove change is guaranteed to be preceeded by a price update
   );
 
   bumpSystemState(systemState);

--- a/packages/subgraph/src/entities/Transaction.ts
+++ b/packages/subgraph/src/entities/Transaction.ts
@@ -3,14 +3,10 @@ import { ethereum } from "@graphprotocol/graph-ts";
 import { Transaction } from "../../generated/schema";
 
 import { getTransactionSequenceNumber } from "./Global";
-import { checkPrice } from "./SystemState";
 
 /*
  * Return existing entity for the transaction that emitted this event, or create and return a new
  * one if none exists yet.
- *
- * When creating a new Transaction, it checks if the price has changed. This may have the side
- * effect of creating new SystemState and PriceChange entities.
  */
 export function getTransaction(event: ethereum.Event): Transaction {
   let transactionId = event.transaction.hash.toHex();
@@ -25,8 +21,6 @@ export function getTransaction(event: ethereum.Event): Transaction {
     newTransaction.blockNumber = event.block.number.toI32();
     newTransaction.timestamp = event.block.timestamp.toI32();
     newTransaction.save();
-
-    checkPrice(event);
 
     return newTransaction;
   }

--- a/packages/subgraph/src/entities/Trove.ts
+++ b/packages/subgraph/src/entities/Trove.ts
@@ -74,7 +74,7 @@ function setTroveStatus(trove: Trove, status: string): void {
 }
 
 function createTroveChange(event: ethereum.Event): TroveChange {
-  let sequenceNumber = beginChange(event);
+  let sequenceNumber = beginChange();
   let troveChange = new TroveChange(sequenceNumber.toString());
   initChange(troveChange, event, sequenceNumber);
 

--- a/packages/subgraph/src/entities/User.ts
+++ b/packages/subgraph/src/entities/User.ts
@@ -23,7 +23,7 @@ export function getUser(_user: Address): User {
 }
 
 function createCollSurplusChange(event: ethereum.Event): CollSurplusChange {
-  let sequenceNumber = beginChange(event);
+  let sequenceNumber = beginChange();
   let collSurplusChange = new CollSurplusChange(sequenceNumber.toString());
   initChange(collSurplusChange, event, sequenceNumber);
 
@@ -52,8 +52,9 @@ export function updateUserClaimColl(
 
   collSurplusChange.collSurplusBefore = user.collSurplus;
   collSurplusChange.collSurplusAfter = newCollSurplus;
-  collSurplusChange.collSurplusChange =
-    collSurplusChange.collSurplusAfter - collSurplusChange.collSurplusBefore;
+  collSurplusChange.collSurplusChange = collSurplusChange.collSurplusAfter.minus(
+    collSurplusChange.collSurplusBefore
+  );
 
   updateSystemStateByCollSurplusChange(collSurplusChange);
   finishCollSurplusChange(collSurplusChange);

--- a/packages/subgraph/src/mappings/PriceFeed.ts
+++ b/packages/subgraph/src/mappings/PriceFeed.ts
@@ -1,0 +1,7 @@
+import { LastGoodPriceUpdated } from "../../generated/PriceFeed/PriceFeed";
+
+import { updatePrice } from "../entities/SystemState";
+
+export function handleLastGoodPriceUpdated(event: LastGoodPriceUpdated): void {
+  updatePrice(event, event.params._lastGoodPrice);
+}

--- a/packages/subgraph/src/mappings/TroveManager.ts
+++ b/packages/subgraph/src/mappings/TroveManager.ts
@@ -3,7 +3,6 @@ import {
   TroveLiquidated,
   Liquidation,
   Redemption,
-  PriceFeedAddressChanged,
   LTermsUpdated
 } from "../../generated/TroveManager/TroveManager";
 
@@ -12,11 +11,7 @@ import { getTroveOperationFromTroveManagerOperation } from "../types/TroveOperat
 import { finishCurrentLiquidation } from "../entities/Liquidation";
 import { finishCurrentRedemption } from "../entities/Redemption";
 import { applyRedistributionToTroveBeforeLiquidation, updateTrove } from "../entities/Trove";
-import { updatePriceFeedAddress, updateTotalRedistributed } from "../entities/Global";
-
-export function handlePriceFeedAddressChanged(event: PriceFeedAddressChanged): void {
-  updatePriceFeedAddress(event.params._newPriceFeedAddress);
-}
+import { updateTotalRedistributed } from "../entities/Global";
 
 export function handleTroveUpdated(event: TroveUpdated): void {
   updateTrove(

--- a/packages/subgraph/src/utils/bignumbers.ts
+++ b/packages/subgraph/src/utils/bignumbers.ts
@@ -12,8 +12,6 @@ export let BIGINT_MAX_UINT256 = BigInt.fromUnsignedBytes(
   Bytes.fromHexString("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF") as Bytes
 );
 
-export let DECIMAL_INITIAL_PRICE = BigDecimal.fromString("200");
-
 export function decimalize(bigInt: BigInt): BigDecimal {
   return bigInt.divDecimal(DECIMAL_SCALING_FACTOR);
 }

--- a/packages/subgraph/subgraph.yaml.js
+++ b/packages/subgraph/subgraph.yaml.js
@@ -34,7 +34,6 @@ dataSources:
         - Global
         - User
         - Transaction
-        - PriceChange
         - Trove
         - TroveChange
         - Redemption
@@ -43,11 +42,7 @@ dataSources:
       abis:
         - name: TroveManager
           file: ../lib-ethers/abi/TroveManager.json
-        - name: PriceFeed
-          file: ../lib-ethers/abi/PriceFeed.json
       eventHandlers:
-        - event: PriceFeedAddressChanged(address)
-          handler: handlePriceFeedAddressChanged
         - event: TroveUpdated(indexed address,uint256,uint256,uint256,uint8)
           handler: handleTroveUpdated
         - event: TroveLiquidated(indexed address,uint256,uint256,uint8)
@@ -74,22 +69,40 @@ dataSources:
         - Global
         - User
         - Transaction
-        - PriceChange
         - Trove
         - TroveChange
         - SystemState
       abis:
         - name: BorrowerOperations
           file: ../lib-ethers/abi/BorrowerOperations.json
-        - name: TroveManager
-          file: ../lib-ethers/abi/TroveManager.json
-        - name: PriceFeed
-          file: ../lib-ethers/abi/PriceFeed.json
       eventHandlers:
         - event: TroveUpdated(indexed address,uint256,uint256,uint256,uint8)
           handler: handleTroveUpdated
         - event: LUSDBorrowingFeePaid(indexed address,uint256)
           handler: handleLUSDBorrowingFeePaid
+  - name: PriceFeed
+    kind: ethereum/contract
+    network: mainnet
+    source:
+      abi: PriceFeed
+      address: "${addresses.priceFeed}"
+      startBlock: ${startBlock}
+    mapping:
+      file: ./src/mappings/PriceFeed.ts
+      language: wasm/assemblyscript
+      kind: ethereum/events
+      apiVersion: 0.0.4
+      entities:
+        - Global
+        - Transaction
+        - PriceChange
+        - SystemState
+      abis:
+        - name: PriceFeed
+          file: ../lib-ethers/abi/PriceFeed.json
+      eventHandlers:
+        - event: LastGoodPriceUpdated(uint256)
+          handler: handleLastGoodPriceUpdated
   - name: StabilityPool
     kind: ethereum/contract
     network: mainnet
@@ -106,7 +119,6 @@ dataSources:
         - Global
         - User
         - Transaction
-        - PriceChange
         - StabilityDeposit
         - StabilityDepositChange
         - SystemState
@@ -114,8 +126,6 @@ dataSources:
       abis:
         - name: StabilityPool
           file: ../lib-ethers/abi/StabilityPool.json
-        - name: PriceFeed
-          file: ../lib-ethers/abi/PriceFeed.json
       eventHandlers:
         - event: UserDepositChanged(indexed address,uint256)
           handler: handleUserDepositChanged
@@ -147,8 +157,6 @@ dataSources:
       abis:
         - name: CollSurplusPool
           file: ../lib-ethers/abi/CollSurplusPool.json
-        - name: PriceFeed
-          file: ../lib-ethers/abi/PriceFeed.json
       eventHandlers:
         - event: CollBalanceUpdated(indexed address,uint256)
           handler: handleCollSurplusBalanceUpdated
@@ -173,8 +181,6 @@ dataSources:
       abis:
         - name: LQTYStaking
           file: ../lib-ethers/abi/LQTYStaking.json
-        - name: PriceFeed
-          file: ../lib-ethers/abi/PriceFeed.json
       eventHandlers:
         - event: StakeChanged(indexed address,uint256)
           handler: handleStakeChanged


### PR DESCRIPTION
Previously, price was checked via `eth_call` upon creating a new Transaction entity.

The problem is that calls see the blockchain state after all the transactions in the
current block have been executed. This means if there was a Liquity TX mined in the
same block as a (Chainlink) price update, but ordered _before_ the price update, the
subgraph would prematurely use the updated price to calculate ICRs while processing
the Liquity TX.

Instead of calling the PriceFeed, use its event `LastGoodPriceUpdated`, which is
correctly ordered with regard to other Liquity events.

Fixes #581.