### PR TITLE
Fix total collateral in subgraph

### DIFF
--- a/packages/subgraph/src/utils/bignumbers.ts
+++ b/packages/subgraph/src/utils/bignumbers.ts
@@ -1,11 +1,15 @@
 import { Bytes, BigInt, BigDecimal } from "@graphprotocol/graph-ts";
 
+export let DECIMAL_PRECISION = 18;
+
 // E.g. 1.5 is represented as 1.5 * 10^18, where 10^18 is called the scaling factor
 export let DECIMAL_SCALING_FACTOR = BigDecimal.fromString("1000000000000000000");
 export let BIGINT_SCALING_FACTOR = BigInt.fromI32(10).pow(18);
 
 export let DECIMAL_ZERO = BigDecimal.fromString("0");
 export let DECIMAL_ONE = BigDecimal.fromString("1");
+
+export let DECIMAL_COLLATERAL_GAS_COMPENSATION_DIVISOR = BigDecimal.fromString("200");
 
 export let BIGINT_ZERO = BigInt.fromI32(0);
 export let BIGINT_MAX_UINT256 = BigInt.fromUnsignedBytes(

--- a/packages/subgraph/src/utils/collateralRatio.ts
+++ b/packages/subgraph/src/utils/collateralRatio.ts
@@ -1,6 +1,6 @@
 import { BigDecimal } from "@graphprotocol/graph-ts";
 
-import { DECIMAL_ZERO } from "./bignumbers";
+import { DECIMAL_PRECISION, DECIMAL_ZERO } from "./bignumbers";
 
 export function calculateCollateralRatio(
   collateral: BigDecimal,
@@ -11,5 +11,5 @@ export function calculateCollateralRatio(
     return null;
   }
 
-  return (collateral * price) / debt;
+  return collateral.times(price).div(debt).truncate(DECIMAL_PRECISION);
 }


### PR DESCRIPTION
Total collateral was incorrect after a redistribution, because we weren't subtracting the 0.5% collateral paid out as gas compensation.
    
Fixes #591.