### PR TITLE
fix: require borrowing at least the minimum net debt

### DIFF
--- a/packages/dev-frontend/src/components/Trove/validation/validateTroveChange.tsx
+++ b/packages/dev-frontend/src/components/Trove/validation/validateTroveChange.tsx
@@ -1,6 +1,7 @@
 import {
   Decimal,
   LUSD_MINIMUM_DEBT,
+  LUSD_MINIMUM_NET_DEBT,
   Trove,
   TroveAdjustmentParams,
   TroveChange,
@@ -161,7 +162,7 @@ export const validateTroveChange = (
 };
 
 const validateTroveCreation = (
-  { depositCollateral }: TroveCreationParams<Decimal>,
+  { depositCollateral, borrowLUSD }: TroveCreationParams<Decimal>,
   {
     resultingTrove,
     recoveryMode,
@@ -170,12 +171,12 @@ const validateTroveCreation = (
     price
   }: TroveChangeValidationContext
 ): JSX.Element | null => {
-  if (resultingTrove.debt.lt(LUSD_MINIMUM_DEBT)) {
+  if (borrowLUSD.lt(LUSD_MINIMUM_NET_DEBT)) {
     return (
       <ErrorDescription>
-        Total debt must be at least{" "}
+        You must borrow at least{" "}
         <Amount>
-          {LUSD_MINIMUM_DEBT.toString()} {COIN}
+          {LUSD_MINIMUM_NET_DEBT.toString()} {COIN}
         </Amount>
         .
       </ErrorDescription>


### PR DESCRIPTION
This prevents sending TXs that are at risk of failing due to decrease of the
borrowing rate (either through decay or entering recovery mode).

This also fixes a problem where the confirm button on the Trove panel could
get stuck if trying to open a Trove with dangerously low debt. The fee decay
estimation logic would throw an error upon seeing the Trove's debt decay
below the minimum within the fee decay tolerance period.

Fixes #613.