### PR TITLE
contracts: Balancer pool deployment last tweaks

### DIFF
--- a/packages/contracts/hardhat.config.js
+++ b/packages/contracts/hardhat.config.js
@@ -71,7 +71,7 @@ module.exports = {
         },
         mainnet: {
             url: alchemyUrl(),
-            gasPrice: 150000000000,
+            gasPrice: process.env.GAS_PRICE ? parseInt(process.env.GAS_PRICE) : 20000000000,
             accounts: [
                 getSecret('DEPLOYER_PRIVATEKEY', '0x60ddfe7f579ab6867cbe7a2dc03853dc141d7a4ab6dbefc0dae2d2b1bd4e487f'),
                 getSecret('ACCOUNT2_PRIVATEKEY', '0x3ec7cedbafd0cb9ec05bf9f7ccfa1e8b42b3e3a02c75addfccbfeb328d1b383b')

--- a/packages/contracts/mainnetDeployment/balancerDeploymentOutput/balancerOutput_20210629.txt
+++ b/packages/contracts/mainnetDeployment/balancerDeploymentOutput/balancerOutput_20210629.txt
@@ -1,0 +1,23 @@
+Deployer:  0x9B5715C99d3A9db84cAA904f9f442220651436e8
+Pool Address:  0x1B46e4B0791C9383B73b64AaBc371360a031a83F
+ETH price: 2214.533518110000000000
+Initial LUSD: 6000.000000000000000000
+Initial WETH: 4.064061314222543754
+weth balance: : 0.000000000000000000
+WETH deposit gas:  45038
+weth balance: : 4.064061314222543754
+Approve WETH gas:  46076
+Approve LUSD gas:  46191
+Final tx status: 1
+Join Pool gas:  210450
+Pool BPT tokens: 150.545107702860401788
+
+Pool at: https://app.balancer.fi/#/pool/0x1b46e4b0791c9383b73b64aabc371360a031a83f000200000000000000000057
+
+Transactions:
+
+https://etherscan.io/tx/0x08feead93214f0f85f5bf92e9161258767e782a902abd79677e87c1868061529
+https://etherscan.io/tx/0x62153e498719607fa03df7e726ad5f17549fc44533af61663424c8a90eba4a65
+https://etherscan.io/tx/0x7052c8d1f112a917a66a56729d6aeb65f3f34288c3680daf720e2355455f809d
+https://etherscan.io/tx/0x4772426f18ff24760e94700facdf07d279ee9bfda1b0335971f352af38216fa9
+https://etherscan.io/tx/0x3cdf409443c2c92ccfa78f0aef4ab6d4fcdcf3898bc0b1ef6a53b5a0b1102984

--- a/packages/contracts/mainnetDeployment/balancerPoolDeployment.js
+++ b/packages/contracts/mainnetDeployment/balancerPoolDeployment.js
@@ -34,22 +34,23 @@ const swapFeePercentage = toBigNum(dec(5, 15)); // 0.5%
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
-const INITIAL_FUNDING = toBigNum(dec(5, 22)); // $50k
+const INITIAL_FUNDING = toBigNum(dec(15, 21)); // $15k
 
 async function main() {
   // Uncomment for testing:
   /*
-  const impersonateAddress = "0x787EfF01c9FdC1918d1AA6eeFf089B191e2922E4"
+  const impersonateAddress = "0x787EfF01c9FdC1918d1AA6eeFf089B191e2922E4";
   await hre.network.provider.request({
     method: "hardhat_impersonateAccount",
     params: [ impersonateAddress ]
-  })
-  const deployerWallet = await ethers.provider.getSigner(impersonateAddress)
-  const deployerWalletAddress = impersonateAddress
+  });
+  const deployerWallet = await ethers.provider.getSigner(impersonateAddress);
+  const deployerWalletAddress = impersonateAddress;
   */
 
-  const deployerWallet = (await ethers.getSigners())[0]
-  const deployerWalletAddress = deployerWallet.address
+  const deployerWallet = (await ethers.getSigners())[0];
+  const deployerWalletAddress = deployerWallet.address;
+  console.log('Deployer: ', deployerWalletAddress);
 
   const factory = new ethers.Contract(
     ORACLE_POOL_FACTORY,
@@ -66,24 +67,32 @@ async function main() {
     CHAINLINK_ETHUSD_PROXY,
     ChainlinkAggregatorV3Interface,
     deployerWallet
-  )
-
-  // ZERO_ADDRESS owner means fixed swap fees
-  // DELEGATE_OWNER grants permission to governance for dynamic fee management
-  // Any other address lets that address directly set the fees
-  const oracleEnabled = true;
-  const tx1 = await factory.create(
-    NAME, SYMBOL, tokens, weights,
-    swapFeePercentage, oracleEnabled,
-    DELEGATE_OWNER
   );
-  const receipt1 = await tx1.wait();
-  console.log('Factory create gas: ', receipt1.gasUsed.toString())
 
-  // We need to get the new pool address out of the PoolCreated event
-  // (Or just grab it from Etherscan)
-  const events = receipt1.events.filter((e) => e.event === 'PoolCreated');
-  const poolAddress = events[0].args.pool;
+  let poolAddress;
+  let receipt1;
+  if (process.env.POOL_ADDRESS) {
+    poolAddress = process.env.POOL_ADDRESS;
+    receipt1 = { gasUsed: toBigNum(0) };
+  } else {
+    // ZERO_ADDRESS owner means fixed swap fees
+    // DELEGATE_OWNER grants permission to governance for dynamic fee management
+    // Any other address lets that address directly set the fees
+    const oracleEnabled = true;
+    const tx1 = await factory.create(
+      NAME, SYMBOL, tokens, weights,
+      swapFeePercentage, oracleEnabled,
+      DELEGATE_OWNER
+    );
+    receipt1 = await tx1.wait();
+    console.log('Create Pool gas: ', receipt1.gasUsed.toString());
+
+    // We need to get the new pool address out of the PoolCreated event
+    // (Or just grab it from Etherscan)
+    const events = receipt1.events.filter((e) => e.event === 'PoolCreated');
+    poolAddress = events[0].args.pool;
+  }
+  console.log('Pool Address: ', poolAddress);
 
   // We're going to need the PoolId later, so ask the contract for it
   const pool = new ethers.Contract(
@@ -97,14 +106,14 @@ async function main() {
   const chainlinkPrice = await chainlinkProxy.latestAnswer();
   // chainlink price has only 8 decimals
   const eth_price = chainlinkPrice.mul(toBigNum(dec(1, 10)));
-  th.logBN('ETH price', eth_price)
+  th.logBN('ETH price', eth_price);
   // Tokens must be in the same order
   // Values must be decimal-normalized!
   const weth_balance = INITIAL_FUNDING.mul(weights[1]).div(eth_price);
   const lusd_balance = INITIAL_FUNDING.mul(weights[0]).div(toBigNum(dec(1, 18)));
   const initialBalances = [lusd_balance, weth_balance];
-  th.logBN('Initial LUSD', lusd_balance)
-  th.logBN('Initial WETH', weth_balance)
+  th.logBN('Initial LUSD', lusd_balance);
+  th.logBN('Initial WETH', weth_balance);
 
   const JOIN_KIND_INIT = 0;
 
@@ -117,7 +126,7 @@ async function main() {
     maxAmountsIn: initialBalances,
     userData: initUserData,
     fromInternalBalance: false
-  }
+  };
 
   // Caller is "you". joinPool takes a sender (source of initialBalances)
   // And a receiver (where BPT are sent). Normally, both are the caller.
@@ -130,39 +139,39 @@ async function main() {
     WETH,
     WETH_ABI.abi,
     deployerWallet
-  )
-  th.logBN('weth balance: ', await weth.balanceOf(deployerWalletAddress))
-  const currentWethBalance = await weth.balanceOf(deployerWalletAddress)
-  let depositWethReceipt
+  );
+  th.logBN('weth balance: ', await weth.balanceOf(deployerWalletAddress));
+  const currentWethBalance = await weth.balanceOf(deployerWalletAddress);
+  let depositWethReceipt;
   if (currentWethBalance.lt(weth_balance)) {
     const txDepositWeth = await weth.deposit({ value: weth_balance.sub(currentWethBalance) });
-    depositWethReceipt = await txDepositWeth.wait()
-    console.log('WETH deposit gas: ', depositWethReceipt.gasUsed.toString())
+    depositWethReceipt = await txDepositWeth.wait();
+    console.log('WETH deposit gas: ', depositWethReceipt.gasUsed.toString());
   }
-  th.logBN('weth balance: ', await weth.balanceOf(deployerWalletAddress))
+  th.logBN('weth balance: ', await weth.balanceOf(deployerWalletAddress));
   const txApproveWeth = await weth.approve(VAULT, weth_balance);
-  const approveWethReceipt = await txApproveWeth.wait()
-  console.log('Approve WETH gas: ', approveWethReceipt.gasUsed.toString())
+  const approveWethReceipt = await txApproveWeth.wait();
+  console.log('Approve WETH gas: ', approveWethReceipt.gasUsed.toString());
 
   // Approve LUSD
   const lusd = new ethers.Contract(
     LUSD,
     ERC20.abi,
     deployerWallet
-  )
+  );
   const txApproveLusd = await lusd.approve(VAULT, lusd_balance);
-  const approveLusdReceipt = await txApproveLusd.wait()
-  console.log('Approve LUSD gas: ', approveLusdReceipt.gasUsed.toString())
+  const approveLusdReceipt = await txApproveLusd.wait();
+  console.log('Approve LUSD gas: ', approveLusdReceipt.gasUsed.toString());
 
   // joins and exits are done on the Vault, not the pool
   const tx2 = await vault.joinPool(poolId, deployerWalletAddress, deployerWalletAddress, joinPoolRequest);
   // You can wait for it like this, or just print the tx hash and monitor
   const receipt2 = await tx2.wait();
-  console.log('Final tx status:', receipt2.status)
-  console.log('Join Pool gas: ', receipt2.gasUsed.toString())
-  th.logBN('Pool BPT tokens', await pool.totalSupply())
+  console.log('Final tx status:', receipt2.status);
+  console.log('Join Pool gas: ', receipt2.gasUsed.toString());
+  th.logBN('Pool BPT tokens', await pool.totalSupply());
 
-  console.log('Total gas: ', receipt1.gasUsed.add(depositWethReceipt.gasUsed).add(approveWethReceipt.gasUsed).add(approveLusdReceipt.gasUsed).add(receipt2.gasUsed).toString())
+  console.log('Total gas: ', receipt1.gasUsed.add(depositWethReceipt.gasUsed).add(approveWethReceipt.gasUsed).add(approveLusdReceipt.gasUsed).add(receipt2.gasUsed).toString());
 }
 
 main()


### PR DESCRIPTION
- Add gas logs.
- Change initial funding to 15k.
- Allow to pass an already deployed address as an env variable to make
  it more resilient.
- Allow to pass gas price as an env variable for mainnet config.
- Add Balancer deployment output file.