### PR TITLE
fix: work around huge gas cost when reducing ICR of bottom Trove

### DIFF
--- a/packages/lib-ethers/src/PopulatableEthersLiquity.ts
+++ b/packages/lib-ethers/src/PopulatableEthersLiquity.ts
@@ -693,7 +693,8 @@ export class PopulatableEthersLiquity
   }
 
   private async _findHintsForNominalCollateralRatio(
-    nominalCollateralRatio: Decimal
+    nominalCollateralRatio: Decimal,
+    ownAddress?: string
   ): Promise<[string, string]> {
     const { sortedTroves, hintHelpers } = _getContracts(this._readable.connection);
     const numberOfTroves = await this._readable.getNumberOfTroves();
@@ -733,21 +734,35 @@ export class PopulatableEthersLiquity
 
     const { hintAddress } = results.reduce((a, b) => (a.diff.lt(b.diff) ? a : b));
 
-    const [prev, next] = await sortedTroves.findInsertPosition(
+    let [prev, next] = await sortedTroves.findInsertPosition(
       nominalCollateralRatio.hex,
       hintAddress,
       hintAddress
     );
 
-    return prev === AddressZero ? [next, next] : next === AddressZero ? [prev, prev] : [prev, next];
+    if (ownAddress) {
+      if (prev === ownAddress) {
+        prev = await sortedTroves.getPrev(prev);
+      } else if (next === ownAddress) {
+        next = await sortedTroves.getNext(next);
+      }
+    }
+
+    if (prev === AddressZero) {
+      prev = next;
+    } else if (next === AddressZero) {
+      next = prev;
+    }
+
+    return [prev, next];
   }
 
-  private async _findHints(trove: Trove): Promise<[string, string]> {
+  private async _findHints(trove: Trove, ownAddress?: string): Promise<[string, string]> {
     if (trove instanceof TroveWithPendingRedistribution) {
       throw new Error("Rewards must be applied to this Trove");
     }
 
-    return this._findHintsForNominalCollateralRatio(trove._nominalCollateralRatio);
+    return this._findHintsForNominalCollateralRatio(trove._nominalCollateralRatio, ownAddress);
   }
 
   private async _findRedemptionHints(
@@ -775,7 +790,10 @@ export class PopulatableEthersLiquity
       partialRedemptionLowerHint
     ] = partialRedemptionHintNICR.isZero()
       ? [AddressZero, AddressZero]
-      : await this._findHintsForNominalCollateralRatio(decimalify(partialRedemptionHintNICR));
+      : await this._findHintsForNominalCollateralRatio(
+          decimalify(partialRedemptionHintNICR)
+          // XXX: if we knew the partially redeemed Trove's address, we'd pass it here
+        );
 
     return [
       decimalify(truncatedLUSDamount),
@@ -942,7 +960,7 @@ export class PopulatableEthersLiquity
 
     const currentBorrowingRate = decayBorrowingRate(0);
     const adjustedTrove = trove.adjust(normalizedParams, currentBorrowingRate);
-    const hints = await this._findHints(adjustedTrove);
+    const hints = await this._findHints(adjustedTrove, address);
 
     const {
       maxBorrowingRate,
@@ -1139,7 +1157,7 @@ export class PopulatableEthersLiquity
       await stabilityPool.estimateAndPopulate.withdrawETHGainToTrove(
         { ...overrides },
         compose(addGasForPotentialListTraversal, addGasForLQTYIssuance),
-        ...(await this._findHints(finalTrove))
+        ...(await this._findHints(finalTrove, address))
       )
     );
   }

--- a/packages/lib-ethers/src/PopulatableEthersLiquity.ts
+++ b/packages/lib-ethers/src/PopulatableEthersLiquity.ts
@@ -741,6 +741,9 @@ export class PopulatableEthersLiquity
     );
 
     if (ownAddress) {
+      // In the case of reinsertion, the address of the Trove being reinserted is not a usable hint,
+      // because it is deleted from the list before the reinsertion.
+      // "Jump over" the Trove to get the proper hint.
       if (prev === ownAddress) {
         prev = await sortedTroves.getPrev(prev);
       } else if (next === ownAddress) {
@@ -748,6 +751,8 @@ export class PopulatableEthersLiquity
       }
     }
 
+    // Don't use `address(0)` as hint as it can result in huge gas cost.
+    // (See https://github.com/liquity/dev/issues/600).
     if (prev === AddressZero) {
       prev = next;
     } else if (next === AddressZero) {


### PR DESCRIPTION
The problem:
> [...] for the last trove in the list, the addressOfLowestICRTrove is their own address - and the reinsertion first removes it before the insert. The system can't find it in the list, so starts at the opposite end, and runs out of gas.

DefiSaver's original workaround:
> [...] check for this specific edge case: if the trove is last in the list, use the 2nd last trove's address as both hints.

This implements a generalized version of that workaround:
 * In either of the hints is the user's own Trove, "jump over" it and replace it with the next/prev Trove.
 * If either of the hints is `address(0)`, replace it with the other hint.

Fixes #659.