### PR TITLE
Update assert import in Fees.ts

### DIFF
--- a/packages/lib-base/src/Fees.ts
+++ b/packages/lib-base/src/Fees.ts
@@ -1,4 +1,4 @@
-import assert from "assert";
+import * as assert from "assert";
 
 import { Decimal, Decimalish } from "./Decimal";
 


### PR DESCRIPTION
`Import assert`  throws `TypeError: assert_1.default is not a function` in different environments like Vite. Is there any way to use assert in not node environment?