### PR TITLE
contracts: Fix back to Normal Mode issue in multi-liquidations

### DIFF
--- a/packages/contracts/contracts/TroveManager.sol
+++ b/packages/contracts/contracts/TroveManager.sol
@@ -149,7 +149,6 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
         uint collGasCompensation;
         uint LUSDGasCompensation;
         uint debtToOffset;
-        uint collToOffset;
         uint collToSendToSP;
         uint debtToRedistribute;
         uint collToRedistribute;
@@ -415,7 +414,7 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
                 collSurplusPool.accountSurplus(_borrower, singleLiquidation.collSurplus);
             }
 
-            emit TroveLiquidated(_borrower, singleLiquidation.entireTroveDebt, singleLiquidation.collToOffset, TroveManagerOperation.liquidateInRecoveryMode);
+            emit TroveLiquidated(_borrower, singleLiquidation.entireTroveDebt, singleLiquidation.collToSendToSP, TroveManagerOperation.liquidateInRecoveryMode);
             emit TroveUpdated(_borrower, 0, 0, 0, TroveManagerOperation.liquidateInRecoveryMode);
 
         } else { // if (_ICR >= MCR && ( _ICR >= _TCR || singleLiquidation.entireTroveDebt > _LUSDInStabPool))
@@ -477,15 +476,14 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
     {
         singleLiquidation.entireTroveDebt = _entireTroveDebt;
         singleLiquidation.entireTroveColl = _entireTroveColl;
-        uint collToOffset = _entireTroveDebt.mul(MCR).div(_price);
+        uint collToLiquidate = _entireTroveDebt.mul(MCR).div(_price);
 
-        singleLiquidation.collGasCompensation = _getCollGasCompensation(collToOffset);
+        singleLiquidation.collGasCompensation = _getCollGasCompensation(collToLiquidate);
         singleLiquidation.LUSDGasCompensation = LUSD_GAS_COMPENSATION;
 
         singleLiquidation.debtToOffset = _entireTroveDebt;
-        singleLiquidation.collToOffset = collToOffset;
-        singleLiquidation.collToSendToSP = collToOffset.sub(singleLiquidation.collGasCompensation);
-        singleLiquidation.collSurplus = _entireTroveColl.sub(collToOffset);
+        singleLiquidation.collToSendToSP = collToLiquidate.sub(singleLiquidation.collGasCompensation);
+        singleLiquidation.collSurplus = _entireTroveColl.sub(collToLiquidate);
         singleLiquidation.debtToRedistribute = 0;
         singleLiquidation.collToRedistribute = 0;
     }
@@ -582,7 +580,10 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
                 // Update aggregate trackers
                 vars.remainingLUSDInStabPool = vars.remainingLUSDInStabPool.sub(singleLiquidation.debtToOffset);
                 vars.entireSystemDebt = vars.entireSystemDebt.sub(singleLiquidation.debtToOffset);
-                vars.entireSystemColl = vars.entireSystemColl.sub(singleLiquidation.collToOffset).sub(singleLiquidation.collSurplus);
+                vars.entireSystemColl = vars.entireSystemColl.
+                    sub(singleLiquidation.collToSendToSP).
+                    sub(singleLiquidation.collGasCompensation).
+                    sub(singleLiquidation.collSurplus);
 
                 // Add liquidation values to their respective running totals
                 totals = _addLiquidationValuesToTotals(totals, singleLiquidation);
@@ -721,7 +722,10 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
                 // Update aggregate trackers
                 vars.remainingLUSDInStabPool = vars.remainingLUSDInStabPool.sub(singleLiquidation.debtToOffset);
                 vars.entireSystemDebt = vars.entireSystemDebt.sub(singleLiquidation.debtToOffset);
-                vars.entireSystemColl = vars.entireSystemColl.sub(singleLiquidation.collToOffset).sub(singleLiquidation.collSurplus);
+                vars.entireSystemColl = vars.entireSystemColl.
+                    sub(singleLiquidation.collToSendToSP).
+                    sub(singleLiquidation.collGasCompensation).
+                    sub(singleLiquidation.collSurplus);
 
                 // Add liquidation values to their respective running totals
                 totals = _addLiquidationValuesToTotals(totals, singleLiquidation);

--- a/packages/contracts/contracts/TroveManager.sol
+++ b/packages/contracts/contracts/TroveManager.sol
@@ -476,14 +476,14 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
     {
         singleLiquidation.entireTroveDebt = _entireTroveDebt;
         singleLiquidation.entireTroveColl = _entireTroveColl;
-        uint collToLiquidate = _entireTroveDebt.mul(MCR).div(_price);
+        uint cappedCollPortion = _entireTroveDebt.mul(MCR).div(_price);
 
-        singleLiquidation.collGasCompensation = _getCollGasCompensation(collToLiquidate);
+        singleLiquidation.collGasCompensation = _getCollGasCompensation(cappedCollPortion);
         singleLiquidation.LUSDGasCompensation = LUSD_GAS_COMPENSATION;
 
         singleLiquidation.debtToOffset = _entireTroveDebt;
-        singleLiquidation.collToSendToSP = collToLiquidate.sub(singleLiquidation.collGasCompensation);
-        singleLiquidation.collSurplus = _entireTroveColl.sub(collToLiquidate);
+        singleLiquidation.collToSendToSP = cappedCollPortion.sub(singleLiquidation.collGasCompensation);
+        singleLiquidation.collSurplus = _entireTroveColl.sub(cappedCollPortion);
         singleLiquidation.debtToRedistribute = 0;
         singleLiquidation.collToRedistribute = 0;
     }


### PR DESCRIPTION
The initial fix was wrong, as now for case of ICR between 100% and
MCR, collToOffset would be zero, so it wouldn’t be subtracted.

Besides, subtracting the gas compensation too, which in that case was
missed too.