### PR TITLE
fix(.gitattributes): prevent github from showing json comments as errors

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 # Enable syntax highlighting for Solidity
 *.sol linguist-language=Solidity
+# Prevent Github highlighting comments in JSON files as errors
+*.json  linguist-language=JSON-with-Comments


### PR DESCRIPTION
Example:

![image](https://user-images.githubusercontent.com/38409137/147714687-8068e654-3e5e-4a7a-8431-29ff4d4c8e27.png)
