### PR TITLE
Calculate LQTY reward APR based on current daily LQTY issuance

### DIFF
--- a/packages/dev-frontend/src/components/Stability/Yield.tsx
+++ b/packages/dev-frontend/src/components/Stability/Yield.tsx
@@ -3,7 +3,6 @@ import { Card, Paragraph, Text } from "theme-ui";
 import { Decimal, LiquityStoreState } from "@liquity/lib-base";
 import { useLiquitySelector } from "@liquity/lib-react";
 import { InfoIcon } from "../InfoIcon";
-import { useLiquity } from "../../hooks/LiquityContext";
 import { Badge } from "../Badge";
 import { fetchLqtyPrice } from "./context/fetchLqtyPrice";
 
@@ -13,27 +12,21 @@ const selector = ({ lusdInStabilityPool, remainingStabilityPoolLQTYReward }: Liq
 });
 
 export const Yield: React.FC = () => {
-  const {
-    liquity: {
-      connection: { addresses }
-    }
-  } = useLiquity();
   const { lusdInStabilityPool, remainingStabilityPoolLQTYReward } = useLiquitySelector(selector);
 
   const [lqtyPrice, setLqtyPrice] = useState<Decimal | undefined>(undefined);
   const hasZeroValue = remainingStabilityPoolLQTYReward.isZero || lusdInStabilityPool.isZero;
-  const lqtyTokenAddress = addresses["lqtyToken"];
 
   useEffect(() => {
     (async () => {
       try {
-        const { lqtyPriceUSD } = await fetchLqtyPrice(lqtyTokenAddress);
+        const { lqtyPriceUSD } = await fetchLqtyPrice();
         setLqtyPrice(lqtyPriceUSD);
       } catch (error) {
         console.error(error);
       }
     })();
-  }, [lqtyTokenAddress]);
+  }, []);
 
   if (hasZeroValue || lqtyPrice === undefined) return null;
 

--- a/packages/dev-frontend/src/components/Stability/context/fetchLqtyPrice.ts
+++ b/packages/dev-frontend/src/components/Stability/context/fetchLqtyPrice.ts
@@ -1,53 +1,75 @@
 import { Decimal } from "@liquity/lib-base";
 
-type UniswapResponse = {
-  data?: {
-    bundle: {
-      ethPrice: string;
-    } | null;
-    token: {
-      derivedETH: string;
-    } | null;
+type CoinGeckoSimplePriceResponse<T extends string, U extends string> = {
+  [P in T]: {
+    [Q in U]: number;
   };
-  errors?: Array<{ message: string }>;
 };
 
-const uniswapQuery = (lqtyTokenAddress: string) => `{
-  token(id: "${lqtyTokenAddress.toLowerCase()}") {
-    derivedETH
-  },
-  bundle(id: 1) {
-    ethPrice
-  },
-}`;
+const hasProp = <T, P extends string>(o: T, p: P): o is T & { [_ in P]: unknown } => p in o;
 
-export async function fetchLqtyPrice(lqtyTokenAddress: string) {
-  const response = await window.fetch("https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v2", {
-    method: "POST",
+const validateCoinGeckoSimplePriceResponse = <T extends string, U extends string>(
+  expectedCoinIds: readonly T[],
+  expectedCurrencies: readonly U[],
+  body: unknown
+): CoinGeckoSimplePriceResponse<T, U> => {
+  if (typeof body !== "object" || body === null) {
+    throw new Error(`unexpected response from CoinGecko`);
+  }
+
+  for (const coinId of expectedCoinIds) {
+    if (!hasProp(body, coinId)) {
+      throw new Error(`coin "${coinId}" missing from CoinGecko response`);
+    }
+
+    const coinPrices = body[coinId];
+
+    for (const currency of expectedCurrencies) {
+      if (!hasProp(coinPrices, currency)) {
+        throw new Error(`currency "${currency}" missing from CoinGecko response`);
+      }
+
+      if (typeof coinPrices[currency] !== "number") {
+        throw new Error(`price of coin "${coinId}" in currency "${currency}" is not a number`);
+      }
+    }
+  }
+
+  return body as CoinGeckoSimplePriceResponse<T, U>;
+};
+
+const fetchCoinGeckoSimplePrice = async <T extends string, U extends string>(
+  coinIds: readonly T[],
+  vsCurrencies: readonly U[]
+): Promise<CoinGeckoSimplePriceResponse<T, U>> => {
+  const simplePriceUrl =
+    "https://api.coingecko.com/api/v3/simple/price?" +
+    new URLSearchParams({
+      ids: coinIds.join(","),
+      vs_currencies: vsCurrencies.join(",")
+    });
+
+  const response = await window.fetch(simplePriceUrl, {
     headers: {
-      "content-type": "application/json"
-    },
-    body: JSON.stringify({
-      query: uniswapQuery(lqtyTokenAddress),
-      variables: null
-    })
+      accept: "application/json"
+    }
   });
+
   if (!response.ok) {
-    return Promise.reject("Network error connecting to Uniswap subgraph");
+    throw new Error(`couldn't fetch price from CoinGecko: got status ${response.status}`);
   }
 
-  const { data, errors }: UniswapResponse = await response.json();
+  return validateCoinGeckoSimplePriceResponse(coinIds, vsCurrencies, await response.json());
+};
 
-  if (errors) {
-    return Promise.reject(errors);
-  }
-
-  if (typeof data?.token?.derivedETH === "string" && typeof data?.bundle?.ethPrice === "string") {
-    const ethPriceUSD = Decimal.from(data.bundle.ethPrice);
-    const lqtyPriceUSD = Decimal.from(data.token.derivedETH).mul(ethPriceUSD);
-
-    return { lqtyPriceUSD };
-  }
-
-  return Promise.reject("Uniswap doesn't have the required data to calculate yield");
+export interface LqtyPriceResponse {
+  lqtyPriceUSD: Decimal;
 }
+
+export const fetchLqtyPrice = async (): Promise<LqtyPriceResponse> => {
+  const response = await fetchCoinGeckoSimplePrice(["liquity"] as const, ["usd"] as const);
+
+  return {
+    lqtyPriceUSD: Decimal.from(response.liquity.usd)
+  };
+};


### PR DESCRIPTION
The way we used to calculate it is akin to calculating the average APR you would get if you stayed in the pool for one year (while the price of LQTY and the LUSD deposited in SP stayed constant).
    
Instead, let's calculate the current daily yield of the pool and annualize that via multiplying by 365, which is more in line with expectations.