### PR TITLE
contracts: add prefix emit to invoke the StabilityPoolETHBalanceUpdated and  ActivePoolLUSDDebtUpdated event.

### DIFF
--- a/packages/contracts/contracts/ActivePool.sol
+++ b/packages/contracts/contracts/ActivePool.sol
@@ -93,13 +93,13 @@ contract ActivePool is Ownable, CheckContract, IActivePool {
     function increaseLUSDDebt(uint _amount) external override {
         _requireCallerIsBOorTroveM();
         LUSDDebt  = LUSDDebt.add(_amount);
-        ActivePoolLUSDDebtUpdated(LUSDDebt);
+        emit ActivePoolLUSDDebtUpdated(LUSDDebt);
     }
 
     function decreaseLUSDDebt(uint _amount) external override {
         _requireCallerIsBOorTroveMorSP();
         LUSDDebt = LUSDDebt.sub(_amount);
-        ActivePoolLUSDDebtUpdated(LUSDDebt);
+        emit ActivePoolLUSDDebtUpdated(LUSDDebt);
     }
 
     // --- 'require' functions ---

--- a/packages/contracts/contracts/StabilityPool.sol
+++ b/packages/contracts/contracts/StabilityPool.sol
@@ -993,6 +993,6 @@ contract StabilityPool is LiquityBase, Ownable, CheckContract, IStabilityPool {
     receive() external payable {
         _requireCallerIsActivePool();
         ETH = ETH.add(msg.value);
-        StabilityPoolETHBalanceUpdated(ETH);
+        emit StabilityPoolETHBalanceUpdated(ETH);
     }
 }


### PR DESCRIPTION
Hi,

I read your code recently and encountered the following line.

https://github.com/liquity/dev/blob/main/packages/contracts/contracts/StabilityPool.sol#L996

https://github.com/liquity/dev/blob/main/packages/contracts/contracts/ActivePool.sol#L96
https://github.com/liquity/dev/blob/main/packages/contracts/contracts/ActivePool.sol#L102

I know that it works without the emit prefix in old solidity versions. However, you used in another place the emit prefix. In addition, I think it will be better for the readability. So I created this PR.  Thank you.
