### PR TITLE
Bonds UI: Add support for automatically refreshing backend values

### DIFF
--- a/packages/dev-frontend/src/App.test.tsx
+++ b/packages/dev-frontend/src/App.test.tsx
@@ -5,8 +5,11 @@ import { Decimal, LUSD_MINIMUM_NET_DEBT, Trove } from "@liquity/lib-base";
 
 import App from "./App";
 
+const TEST_TIMEOUT = 5000;
 const params = { depositCollateral: Decimal.from(20), borrowLUSD: LUSD_MINIMUM_NET_DEBT };
 const trove = Trove.create(params);
+
+jest.setTimeout(TEST_TIMEOUT);
 
 console.log(`${trove}`);
 
@@ -16,7 +19,11 @@ console.log(`${trove}`);
 test("there's no smoke", async () => {
   const { getByText, getByLabelText, findByText } = render(<App />);
 
-  expect(await findByText(/you can borrow lusd by opening a trove/i)).toBeInTheDocument();
+  expect(
+    await findByText(/you can borrow lusd by opening a trove/i, undefined, {
+      timeout: TEST_TIMEOUT
+    })
+  ).toBeInTheDocument();
 
   fireEvent.click(getByText(/open trove/i));
   fireEvent.click(getByLabelText(/collateral/i));

--- a/packages/dev-frontend/src/App.tsx
+++ b/packages/dev-frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Web3ReactProvider } from "@web3-react/core";
-import { Flex, Spinner, Heading, ThemeProvider, Paragraph, Link } from "theme-ui";
+import { Flex, Heading, ThemeProvider, Paragraph, Link } from "theme-ui";
 
 import { BatchedWebSocketAugmentedWeb3Provider } from "@liquity/providers";
 import { LiquityProvider } from "./hooks/LiquityContext";
@@ -12,6 +12,7 @@ import theme from "./theme";
 
 import { DisposableWalletProvider } from "./testUtils/DisposableWalletProvider";
 import { LiquityFrontend } from "./LiquityFrontend";
+import { AppLoader } from "./components/AppLoader";
 
 if (window.ethereum) {
   // Silence MetaMask warning in console
@@ -71,13 +72,6 @@ const UnsupportedMainnetFallback: React.FC = () => (
 );
 
 const App = () => {
-  const loader = (
-    <Flex sx={{ alignItems: "center", justifyContent: "center", height: "100vh" }}>
-      <Spinner sx={{ m: 2, color: "text" }} size="32px" />
-      <Heading>Loading...</Heading>
-    </Flex>
-  );
-
   const unsupportedNetworkFallback = (chainId: number) => (
     <Flex
       sx={{
@@ -99,14 +93,14 @@ const App = () => {
   return (
     <EthersWeb3ReactProvider>
       <ThemeProvider theme={theme}>
-        <WalletConnector loader={loader}>
+        <WalletConnector loader={<AppLoader />}>
           <LiquityProvider
-            loader={loader}
+            loader={<AppLoader />}
             unsupportedNetworkFallback={unsupportedNetworkFallback}
             unsupportedMainnetFallback={<UnsupportedMainnetFallback />}
           >
             <TransactionProvider>
-              <LiquityFrontend loader={loader} />
+              <LiquityFrontend loader={<AppLoader />} />
             </TransactionProvider>
           </LiquityProvider>
         </WalletConnector>

--- a/packages/dev-frontend/src/components/AppLoader.tsx
+++ b/packages/dev-frontend/src/components/AppLoader.tsx
@@ -1,0 +1,8 @@
+import { Flex, Spinner, Heading } from "theme-ui";
+
+export const AppLoader = () => (
+  <Flex sx={{ alignItems: "center", justifyContent: "center", height: "100vh" }}>
+    <Spinner sx={{ m: 2, color: "text" }} size="32px" />
+    <Heading>Loading...</Heading>
+  </Flex>
+);

--- a/packages/dev-frontend/src/components/Bonds/Bonds.tsx
+++ b/packages/dev-frontend/src/components/Bonds/Bonds.tsx
@@ -3,9 +3,22 @@ import { useBondView } from "./context/BondViewContext";
 import { Idle } from "./views/idle/Idle";
 import { Actioning } from "./views/actioning/Actioning";
 import { Creating } from "./views/creating/Creating";
+import { InfoMessage } from "../InfoMessage";
+import { Container } from "theme-ui";
 
 export const Bonds: React.FC = () => {
-  const { view } = useBondView();
+  const { view, hasFoundContracts } = useBondView();
+
+  if (!hasFoundContracts) {
+    return (
+      <Container sx={{ position: "absolute", left: "30%", top: "40%" }}>
+        <InfoMessage title="Unsupported network">
+          LUSD Bonds haven't been deployed to this network. Please use Ethereum mainnet.
+        </InfoMessage>
+      </Container>
+    );
+  }
+
   let View = null;
   switch (view) {
     case "CANCELLING":

--- a/packages/dev-frontend/src/components/Bonds/Record.tsx
+++ b/packages/dev-frontend/src/components/Bonds/Record.tsx
@@ -1,5 +1,6 @@
 import { ThemeUIStyleObject, Flex, Card, Text } from "theme-ui";
 import { InfoIcon } from "../InfoIcon";
+import { Placeholder } from "../Placeholder";
 
 type RecordType = {
   name: string;
@@ -16,9 +17,9 @@ export const Record: React.FC<RecordType> = ({ name, description, value, type, s
         {name} <InfoIcon size="xs" tooltip={<Card variant="tooltip">{description}</Card>} />
       </Flex>
       <Text as="h3" sx={{ display: "flex", justifyContent: "center" }}>
-        <Text sx={{ fontWeight: "400" }}>{value || "..."}</Text>
+        {value ? <Text sx={{ fontWeight: "400" }}>{value}</Text> : <Placeholder />}
         &nbsp;
-        <Text sx={{ fontWeight: "light", opacity: 0.8 }}>{type}</Text>
+        {value && <Text sx={{ fontWeight: "light", opacity: 0.8 }}>{type}</Text>}
       </Text>
     </Flex>
   );

--- a/packages/dev-frontend/src/components/Bonds/context/BondViewContext.tsx
+++ b/packages/dev-frontend/src/components/Bonds/context/BondViewContext.tsx
@@ -7,7 +7,8 @@ import type {
   Bond,
   Stats,
   BondTransactionStatuses,
-  ProtocolInfo
+  ProtocolInfo,
+  OptimisticBond
 } from "./transitions";
 import { PENDING_STATUS, CANCELLED_STATUS, CLAIMED_STATUS } from "../lexicon";
 import { Decimal } from "@liquity/lib-base";
@@ -24,12 +25,12 @@ export type BondViewContextType = {
   cancelBond: (bondId: string, minimumLusd: Decimal) => Promise<void>;
   claimBond: (bondId: string) => Promise<void>;
   selectedBond?: Bond;
-  optimisticBond?: Bond;
+  optimisticBond?: OptimisticBond;
   bLusdBalance?: Decimal;
   lusdBalance?: Decimal;
   statuses: BondTransactionStatuses;
   isInfiniteBondApproved: boolean;
-  isSynchronising: boolean;
+  isSynchronizing: boolean;
   getLusdFromFaucet: () => Promise<void>;
   simulatedProtocolInfo?: ProtocolInfo;
   setSimulatedMarketPrice: (marketPrice: Decimal) => void;

--- a/packages/dev-frontend/src/components/Bonds/context/BondViewContext.tsx
+++ b/packages/dev-frontend/src/components/Bonds/context/BondViewContext.tsx
@@ -35,6 +35,7 @@ export type BondViewContextType = {
   simulatedProtocolInfo?: ProtocolInfo;
   setSimulatedMarketPrice: (marketPrice: Decimal) => void;
   resetSimulatedMarketPrice: () => void;
+  hasFoundContracts: boolean;
 };
 
 export const BondViewContext = createContext<BondViewContextType | null>(null);

--- a/packages/dev-frontend/src/components/Bonds/context/api.ts
+++ b/packages/dev-frontend/src/components/Bonds/context/api.ts
@@ -29,10 +29,7 @@ const getAccountBonds = async (
   claimBondFee: Decimal,
   floorPrice: Decimal
 ): Promise<Bond[]> => {
-  console.log("getAccountBonds() started");
   const totalBonds = (await bondNft.balanceOf(account)).toNumber();
-
-  console.log("getAccountBonds()", { totalBonds });
 
   const bondIdRequests = Array.from(Array(totalBonds)).map((_, index) =>
     bondNft.tokenOfOwnerByIndex(account, index)
@@ -54,8 +51,6 @@ const getAccountBonds = async (
   const bondEndTimes = await Promise.all(bondRequests.endTimes);
   const bondStatuses = await Promise.all(bondRequests.statuses);
   const bondTokenUris = await Promise.all(bondRequests.tokenUris);
-
-  console.log("getAccountBonds()", { bondIds });
 
   const bonds = bondIds
     .reduce<Bond[]>((accumulator, _, idx) => {
@@ -110,7 +105,6 @@ const getAccountBonds = async (
       ];
     }, [])
     .sort((a, b) => (a.startTime > b.startTime ? -1 : a.startTime < b.startTime ? 1 : 0));
-  console.log("getAccountBonds() finished");
 
   return bonds;
 };

--- a/packages/dev-frontend/src/components/Bonds/context/transitions.ts
+++ b/packages/dev-frontend/src/components/Bonds/context/transitions.ts
@@ -88,6 +88,8 @@ export type Bond = {
   claimNowReturn: string;
 };
 
+export type OptimisticBond = Pick<Bond, "id" | "deposit" | "startTime" | "status">;
+
 export type Treasury = {
   pending: Decimal;
   reserve: Decimal;

--- a/packages/dev-frontend/src/components/Bonds/context/useBondContracts.tsx
+++ b/packages/dev-frontend/src/components/Bonds/context/useBondContracts.tsx
@@ -1,0 +1,86 @@
+import {
+  BLUSDToken,
+  BondNFT,
+  ChickenBondManager,
+  ERC20Faucet,
+  ERC20Faucet__factory
+} from "@liquity/chicken-bonds/lusd/types";
+import type { CurveCryptoSwap2ETH } from "@liquity/chicken-bonds/lusd/types/external";
+import { CurveCryptoSwap2ETH__factory } from "@liquity/chicken-bonds/lusd/types/external";
+import {
+  BLUSDToken__factory,
+  BondNFT__factory,
+  ChickenBondManager__factory
+} from "@liquity/chicken-bonds/lusd/types";
+import {
+  BLUSD_AMM_ADDRESS,
+  BLUSD_TOKEN_ADDRESS,
+  BOND_NFT_ADDRESS,
+  CHICKEN_BOND_MANAGER_ADDRESS,
+  LUSD_OVERRIDE_ADDRESS
+} from "@liquity/chicken-bonds/lusd/addresses";
+import type { LUSDToken } from "@liquity/lib-ethers/dist/types";
+import LUSDTokenAbi from "@liquity/lib-ethers/abi/LUSDToken.json";
+import { useContract } from "../../../hooks/useContract";
+import { useLiquity } from "../../../hooks/LiquityContext";
+
+type BondContracts = {
+  lusdToken: LUSDToken | undefined;
+  bLusdToken: BLUSDToken | undefined;
+  bondNft: BondNFT | undefined;
+  chickenBondManager: ChickenBondManager | undefined;
+  bLusdAmm: CurveCryptoSwap2ETH | undefined;
+  hasFoundContracts: boolean;
+};
+
+export const useBondContracts = (): BondContracts => {
+  const { liquity } = useLiquity();
+
+  const [lusdTokenDefault, lusdTokenDefaultStatus] = useContract<LUSDToken>(
+    liquity.connection.addresses.lusdToken,
+    LUSDTokenAbi
+  );
+  const [lusdTokenOverride, lusdTokenOverrideStatus] = useContract<ERC20Faucet>(
+    LUSD_OVERRIDE_ADDRESS,
+    ERC20Faucet__factory.abi
+  );
+
+  const [lusdToken, lusdTokenStatus] =
+    LUSD_OVERRIDE_ADDRESS === null
+      ? [lusdTokenDefault, lusdTokenDefaultStatus]
+      : [(lusdTokenOverride as unknown) as LUSDToken, lusdTokenOverrideStatus];
+
+  const [bLusdToken, bLusdTokenStatus] = useContract<BLUSDToken>(
+    BLUSD_TOKEN_ADDRESS,
+    BLUSDToken__factory.abi
+  );
+
+  const [bondNft, bondNftStatus] = useContract<BondNFT>(BOND_NFT_ADDRESS, BondNFT__factory.abi);
+  const [chickenBondManager, chickenBondManagerStatus] = useContract<ChickenBondManager>(
+    CHICKEN_BOND_MANAGER_ADDRESS,
+    ChickenBondManager__factory.abi
+  );
+
+  const [bLusdAmm, bLusdAmmStatus] = useContract<CurveCryptoSwap2ETH>(
+    BLUSD_AMM_ADDRESS,
+    CurveCryptoSwap2ETH__factory.abi
+  );
+
+  const hasFoundContracts =
+    [
+      lusdTokenStatus,
+      bondNftStatus,
+      chickenBondManagerStatus,
+      bLusdTokenStatus,
+      bLusdAmmStatus
+    ].find(status => status === "FAILED") === undefined;
+
+  return {
+    lusdToken,
+    bLusdToken,
+    bondNft,
+    chickenBondManager,
+    bLusdAmm,
+    hasFoundContracts
+  };
+};

--- a/packages/dev-frontend/src/components/Bonds/views/actioning/actions/cancel/Cancel.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/actioning/actions/cancel/Cancel.tsx
@@ -1,14 +1,14 @@
-import React, { useState } from "react";
+import React from "react";
 import { Flex, Button, Text, Spinner } from "theme-ui";
 import { ActionDescription } from "../../../../../ActionDescription";
 import { useBondView } from "../../../../context/BondViewContext";
 
 export const Cancel: React.FC = () => {
-  const { dispatchEvent, selectedBond: bond } = useBondView();
-  const [isProcessingTransaction, setIsProcessingTransaction] = useState(false);
+  const { dispatchEvent, selectedBond: bond, statuses } = useBondView();
+
+  const isProcessingTransaction = statuses.CANCEL === "PENDING";
 
   const handleConfirmPressed = () => {
-    setIsProcessingTransaction(true);
     dispatchEvent("CONFIRM_PRESSED");
   };
 
@@ -24,7 +24,6 @@ export const Cancel: React.FC = () => {
         You will receive your bonded{" "}
         <Text sx={{ fontWeight: "bold" }}>{bond.deposit.prettify(2)} LUSD</Text> back and forgo{" "}
         <Text sx={{ fontWeight: "bold" }}>{bond.accrued.shorten()} bLUSD</Text>
-        {isProcessingTransaction && <Flex mt={1}>Transaction processing...</Flex>}
       </ActionDescription>
 
       <Flex variant="layout.actions">

--- a/packages/dev-frontend/src/components/Bonds/views/actioning/actions/claim/Claim.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/actioning/actions/claim/Claim.tsx
@@ -1,16 +1,17 @@
-import React, { useState } from "react";
+import React from "react";
 import { Flex, Button, Text, Spinner } from "theme-ui";
 import { ActionDescription } from "../../../../../ActionDescription";
 import { useBondView } from "../../../../context/BondViewContext";
 
 export const Claim: React.FC = () => {
-  const { dispatchEvent, selectedBond: bond } = useBondView();
-  const [isProcessingTransaction, setIsProcessingTransaction] = useState(false);
+  const { dispatchEvent, selectedBond: bond, statuses } = useBondView();
+
+  const isProcessingTransaction = statuses.CLAIM === "PENDING";
 
   const handleConfirmPressed = () => {
-    setIsProcessingTransaction(true);
     dispatchEvent("CONFIRM_PRESSED");
   };
+
   const handleBackPressed = () => {
     dispatchEvent("BACK_PRESSED");
   };
@@ -23,7 +24,6 @@ export const Claim: React.FC = () => {
         You will receive <Text sx={{ fontWeight: "bold" }}>{bond.accrued.prettify(2)} bLUSD</Text>{" "}
         and forgo your bonded{" "}
         <Text sx={{ fontWeight: "bold" }}>{bond.deposit.prettify(2)} LUSD</Text>
-        {isProcessingTransaction && <Flex mt={1}>Transaction processing...</Flex>}
       </ActionDescription>
 
       <Flex variant="layout.actions">

--- a/packages/dev-frontend/src/components/Bonds/views/idle/BondList.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/idle/BondList.tsx
@@ -3,26 +3,30 @@ import { Flex } from "theme-ui";
 import { Redirect, Route, Switch, useRouteMatch } from "react-router-dom";
 import { Link } from "../../../Link";
 import { FilteredBondList } from "./FilteredBondList";
+import { useBondView } from "../../context/BondViewContext";
 
 export const BondList: React.FC = () => {
+  const { bonds } = useBondView();
   const { url, path } = useRouteMatch();
 
   return (
     <>
-      <Flex as="nav">
-        <Link to={`${url}/all`} p={2}>
-          All
-        </Link>
-        <Link to={`${url}/pending`} p={2}>
-          Pending
-        </Link>
-        <Link to={`${url}/claimed`} p={2}>
-          Claimed
-        </Link>
-        <Link to={`${url}/cancelled`} p={2}>
-          Cancelled
-        </Link>
-      </Flex>
+      {bonds && (
+        <Flex as="nav">
+          <Link to={`${url}/all`} p={2}>
+            All
+          </Link>
+          <Link to={`${url}/pending`} p={2}>
+            Pending
+          </Link>
+          <Link to={`${url}/claimed`} p={2}>
+            Claimed
+          </Link>
+          <Link to={`${url}/cancelled`} p={2}>
+            Cancelled
+          </Link>
+        </Flex>
+      )}
 
       <Switch>
         <Route exact path={path}>

--- a/packages/dev-frontend/src/components/Bonds/views/idle/FilteredBondList.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/idle/FilteredBondList.tsx
@@ -2,6 +2,7 @@ import { useParams } from "react-router-dom";
 import { useBondView } from "../../context/BondViewContext";
 import type { BondStatus, Bond as BondType } from "../../context/transitions";
 import { Bond } from "./Bond";
+import { OptimisticBond } from "./OptimisticBond";
 
 type BondFilter = "pending" | "claimed" | "cancelled";
 
@@ -19,14 +20,22 @@ type FilteredBondsParams = { bondFilter: BondFilter | "all" };
 export const FilteredBondList = () => {
   const { bonds, optimisticBond } = useBondView();
   const { bondFilter } = useParams<FilteredBondsParams>();
+
   if (bonds === undefined) return null;
 
+  const isAllOrPending = bondFilter === "all" || bondFilter === "pending";
+  const showOptimisticBond = optimisticBond !== undefined && isAllOrPending;
+
   const filteredBonds = bondFilter === "all" ? bonds : getFilteredBonds(bonds, bondFilter);
+
   return (
     <>
-      {optimisticBond && <Bond bond={optimisticBond} style={{ mt: "16px" }} />}
+      {
+        // @ts-ignore (TS doesn't realise optimisticBond can't be undefined here)
+        showOptimisticBond && <OptimisticBond bond={optimisticBond} style={{ mt: "16px" }} />
+      }
       {filteredBonds.map((bond: BondType, idx: number) => {
-        const isFirst = idx === 0 && !optimisticBond;
+        const isFirst = idx === 0 && !showOptimisticBond;
         const style = { mt: isFirst ? "16px" : "32px" };
         return <Bond bond={bond} key={idx} style={style} />;
       })}

--- a/packages/dev-frontend/src/components/Bonds/views/idle/Idle.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/idle/Idle.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Card, Box, Heading, Flex, Button, Spinner, Container } from "theme-ui";
+import { Card, Box, Heading, Flex, Button } from "theme-ui";
 import { Empty } from "./Empty";
 import { BondList } from "./BondList";
 import { useBondView } from "../../context/BondViewContext";
@@ -8,13 +8,11 @@ import { InfoIcon } from "../../../InfoIcon";
 import { LUSD_OVERRIDE_ADDRESS } from "@liquity/chicken-bonds/lusd/addresses";
 
 export const Idle: React.FC = () => {
-  const { dispatchEvent, bonds, isSynchronising, getLusdFromFaucet, lusdBalance } = useBondView();
-
-  if (lusdBalance === undefined) return null;
+  const { dispatchEvent, bonds, isSynchronizing, getLusdFromFaucet, lusdBalance } = useBondView();
 
   const hasBonds = bonds !== undefined && bonds.length > 0;
 
-  const showLusdFaucet = LUSD_OVERRIDE_ADDRESS !== null && lusdBalance.eq(0);
+  const showLusdFaucet = LUSD_OVERRIDE_ADDRESS !== null && lusdBalance?.eq(0);
 
   return (
     <>
@@ -25,26 +23,17 @@ export const Idle: React.FC = () => {
           </Button>
         </Flex>
       )}
-      {(hasBonds || isSynchronising) && (
+      {hasBonds && (
         <>
-          <Flex variant="layout.actions" mt={4}>
-            <Flex sx={{ alignItems: "center" }}>
-              {isSynchronising && <>Fetching latest bond data...</>}
-            </Flex>
-            <Button
-              variant="primary"
-              onClick={() => dispatchEvent("CREATE_BOND_PRESSED")}
-              disabled={isSynchronising}
-            >
-              {!isSynchronising && <>Create another bond</>}
-              {isSynchronising && <Spinner size="28px" sx={{ color: "white" }} />}
+          <Flex mt={4} variant="layout.actions">
+            <Button variant="primary" onClick={() => dispatchEvent("CREATE_BOND_PRESSED")}>
+              Create another bond
             </Button>
           </Flex>
           <BondList />
-          {isSynchronising && <Container variant="disabledOverlay" />}
         </>
       )}
-      {!hasBonds && !isSynchronising && (
+      {!hasBonds && !isSynchronizing && (
         <Card>
           <Heading>
             <Flex>

--- a/packages/dev-frontend/src/components/Bonds/views/idle/OptimisticBond.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/idle/OptimisticBond.tsx
@@ -1,0 +1,176 @@
+import { Card, Flex, Button, Link, Image, ThemeUIStyleObject } from "theme-ui";
+import { EventType, HorizontalTimeline, UNKNOWN_DATE } from "../../../HorizontalTimeline";
+import { nfts } from "../../context/BondViewProvider";
+import { Record } from "../../Record";
+import { Actions } from "./actions/Actions";
+import type { OptimisticBond as OptimisticBondType } from "../../context/transitions";
+import { Label, SubLabel } from "../../../HorizontalTimeline";
+import * as l from "../../lexicon";
+
+const getBondEvents = (bond: OptimisticBondType): EventType[] => {
+  return [
+    {
+      date: new Date(bond.startTime),
+      label: (
+        <>
+          <Label description="bLUSD accrual starts off at 0 and increases over time.">
+            {l.BOND_CREATED.term}
+          </Label>
+          <SubLabel>{`0.00 bLUSD`}</SubLabel>
+        </>
+      )
+    },
+    {
+      date: new Date(Date.now()),
+      label: (
+        <>
+          <Label description={l.ACCRUED_AMOUNT.description} style={{ fontWeight: 500 }}>
+            {l.ACCRUED_AMOUNT.term}
+          </Label>
+          <SubLabel style={{ fontWeight: 400 }}></SubLabel>
+        </>
+      ),
+      isSelected: true
+    },
+    {
+      date: UNKNOWN_DATE,
+      label: (
+        <>
+          <Label description="How many bLUSD are required to break-even at the current market price.">
+            {l.BREAK_EVEN_TIME.term}
+          </Label>
+          <SubLabel style={{ fontWeight: 400 }}></SubLabel>
+        </>
+      )
+    },
+    {
+      date: UNKNOWN_DATE,
+      label: (
+        <>
+          <Label description="How many bLUSD are recommended before claiming the bond, selling the bLUSD for LUSD, and then opening another bond.">
+            {l.OPTIMUM_REBOND_TIME.term}
+          </Label>
+          <SubLabel style={{ fontWeight: 400 }}></SubLabel>
+        </>
+      )
+    }
+  ];
+};
+
+type BondProps = { bond: OptimisticBondType; style?: ThemeUIStyleObject };
+
+export const OptimisticBond: React.FC<BondProps> = ({ bond, style }) => {
+  const events = getBondEvents(bond);
+
+  return (
+    <Flex
+      sx={{
+        justifyContent: "center",
+        alignItems: "center",
+        gap: "12px",
+        ...style
+      }}
+    >
+      <Flex>
+        {bond.status === "PENDING" && (
+          <Image
+            sx={{ height: 200, cursor: "pointer", borderRadius: 12 }}
+            src={nfts[bond.status]}
+            alt="TODO"
+            onClick={() => {
+              window.open("https://opensea.io", "_blank");
+            }}
+          />
+        )}
+        {bond.status === "CANCELLED" && (
+          <>
+            <Image sx={{ width: 148, cursor: "pointer", borderRadius: 12 }} src={nfts.PENDING} />
+            <Image
+              sx={{
+                width: 148,
+                cursor: "pointer",
+                borderRadius: "50%",
+                backgroundColor: "transparent",
+                ml: -148,
+                p: "28px"
+              }}
+              src={nfts[bond.status]}
+              alt="TODO"
+              onClick={() => {
+                window.open("https://opensea.io", "_blank");
+              }}
+            />
+          </>
+        )}
+        {bond.status === "CLAIMED" && (
+          <>
+            <Image sx={{ width: 148, cursor: "pointer", borderRadius: 12 }} src={nfts.PENDING} />
+            <Image
+              sx={{
+                width: 148,
+                cursor: "pointer",
+                borderRadius: "50%",
+                backgroundColor: "transparent",
+                ml: -148,
+                p: "28px"
+              }}
+              src={nfts[bond.status]}
+              alt="TODO"
+              onClick={() => {
+                window.open("https://opensea.io", "_blank");
+              }}
+            />
+          </>
+        )}
+      </Flex>
+      <Card mt={[0, 0, 0, 0]} sx={{ borderRadius: 12, flexGrow: 1 }}>
+        <Flex p={[2, 3]} sx={{ flexDirection: "column" }}>
+          <HorizontalTimeline
+            style={{ fontSize: "14.5px", justifyContent: "center", pt: 2, mx: 3 }}
+            events={events}
+          />
+
+          <Flex mt={4} variant="layout.actions" sx={{ justifyContent: "flex-end" }}>
+            <Flex
+              sx={{
+                justifyContent: "flex-start",
+                flexGrow: 1,
+                alignItems: "center",
+                pl: 4,
+                gap: "0 28px",
+                fontSize: "14.5px"
+              }}
+            >
+              <Record
+                name={l.BOND_DEPOSIT.term}
+                value={bond.deposit.prettify(2)}
+                type="LUSD"
+                description={l.BOND_DEPOSIT.description}
+              />
+              {bond.status === "PENDING" && (
+                <Record
+                  name={l.MARKET_VALUE.term}
+                  type="LUSD"
+                  description={l.MARKET_VALUE.description}
+                />
+              )}
+            </Flex>
+            {bond.status === "PENDING" && <Actions bondId={bond.id} disabled />}
+            {bond.status !== "PENDING" && bond.status === "CLAIMED" && (
+              <Button variant="outline" sx={{ height: "44px" }}>
+                <Link
+                  variant="outline"
+                  href="https://curve.fi"
+                  sx={{ textDecoration: "none" }}
+                  target="external"
+                >
+                  Sell bLUSD
+                </Link>
+              </Button>
+            )}
+          </Flex>
+        </Flex>
+      </Card>
+    </Flex>
+  );
+};

--- a/packages/dev-frontend/src/components/Bonds/views/idle/actions/Actions.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/idle/actions/Actions.tsx
@@ -4,11 +4,13 @@ import { useBondView } from "../../../context/BondViewContext";
 import type { SelectBondPayload } from "../../../context/transitions";
 import { CANCEL_BOND, CLAIM_BOND } from "../../../lexicon";
 
+const CHICKEN_EMOJI_CURSOR = `url("data:image/svg+xml;utf8, <svg xmlns='http://www.w3.org/2000/svg' width='32' height='32'  style='font-size: 24px'><text y='20'>🐔</text></svg>"), auto`;
 type ActionsProps = {
   bondId: string;
+  disabled?: boolean;
 };
 
-export const Actions: React.FC<ActionsProps> = ({ bondId }) => {
+export const Actions: React.FC<ActionsProps> = ({ bondId, disabled = false }) => {
   const { dispatchEvent } = useBondView();
 
   const handleCancelBondPressed = () => {
@@ -20,23 +22,27 @@ export const Actions: React.FC<ActionsProps> = ({ bondId }) => {
     dispatchEvent("CLAIM_BOND_PRESSED", { bondId } as SelectBondPayload);
   };
 
+  const cursor = disabled ? "auto" : CHICKEN_EMOJI_CURSOR;
+
   return (
     <>
       <Button
+        disabled={disabled}
         variant="outline"
         sx={{ height: "44px" }}
         style={{
-          cursor: `url("data:image/svg+xml;utf8, <svg xmlns='http://www.w3.org/2000/svg' width='32' height='32'  style='font-size: 24px'><text y='20'>🐔</text></svg>"), auto`
+          cursor
         }}
         onClick={handleCancelBondPressed}
       >
         {CANCEL_BOND.term}
       </Button>
       <Button
+        disabled={disabled}
         variant="outline"
         sx={{ height: "44px" }}
         style={{
-          cursor: `url("data:image/svg+xml;utf8, <svg xmlns='http://www.w3.org/2000/svg' width='32' height='32'  style='font-size: 24px'><text y='20'>🐔</text></svg>"), auto`
+          cursor
         }}
         onClick={handleClaimBondPressed}
       >

--- a/packages/dev-frontend/src/components/HorizontalTimeline.tsx
+++ b/packages/dev-frontend/src/components/HorizontalTimeline.tsx
@@ -3,6 +3,7 @@ import { Flex, Box, Text, Card } from "theme-ui";
 import type { ThemeUIStyleObject } from "theme-ui";
 import { InfoIcon } from "./InfoIcon";
 import { dateWithoutHours } from "./Bonds/utils";
+import { Placeholder } from "./Placeholder";
 
 const defaultCircleStyle = {
   height: 12,
@@ -54,6 +55,9 @@ const Line: React.FC<LineProps> = ({ style }) => {
   return <Box sx={{ ...defaultLineStyle, ...style }} />;
 };
 
+// Use the maximum possible date to represent unknown
+export const UNKNOWN_DATE = new Date(8640000000000000);
+
 export type EventType = {
   date: Date;
   label: React.ReactNode;
@@ -75,7 +79,18 @@ type LabelProps = {
 
 type SubLabelProps = { style?: ThemeUIStyleObject };
 export const SubLabel: React.FC<SubLabelProps> = ({ style, children }) => (
-  <Flex sx={{ fontWeight: 200, fontSize: "0.98em", alignSelf: "center", ...style }}>{children}</Flex>
+  <Flex
+    sx={{
+      fontWeight: 200,
+      fontSize: "0.98em",
+      alignSelf: "center",
+      justifyContent: "center",
+      flexGrow: 1,
+      ...style
+    }}
+  >
+    {children}
+  </Flex>
 );
 
 export const Label: React.FC<LabelProps> = ({ children, description, style }) => {
@@ -146,9 +161,17 @@ const Event: React.FC<EventProps> = ({ isFirst, isLast, date, label, idx, select
       ? "Now"
       : date.toLocaleDateString("en-GB", { month: "short", day: "2-digit", year: "numeric" });
 
+  const isUnknownDate = date === UNKNOWN_DATE;
+
   return (
     <Flex sx={{ flexDirection: "column", flexGrow: 1 }}>
-      <Text sx={{ fontWeight: 400, alignSelf: "center" }}>{dateText}</Text>
+      <Flex sx={{ justifyContent: "center" }}>
+        {isUnknownDate ? (
+          <Placeholder />
+        ) : (
+          <Text sx={{ fontWeight: 400, alignSelf: "center" }}>{dateText}</Text>
+        )}
+      </Flex>
       <Flex sx={{ my: 1, alignItems: "center" }}>
         <Line style={leftLineStyle} />
         <Circle style={circleStyle} />

--- a/packages/dev-frontend/src/components/Placeholder.tsx
+++ b/packages/dev-frontend/src/components/Placeholder.tsx
@@ -1,0 +1,39 @@
+import { Flex } from "theme-ui";
+import { keyframes } from "@emotion/react";
+
+const loading = keyframes`
+  from {
+    left: -25%;
+  }
+  to {
+    left: 100%;
+  }
+`;
+
+export const Placeholder = () => {
+  return (
+    <Flex
+      sx={{
+        position: "relative",
+        backgroundColor: "rgb(225, 230, 230)",
+        overflow: "hidden",
+        borderRadius: "5px",
+        height: "100%",
+        width: "56%"
+      }}
+    >
+      <Flex
+        sx={{
+          position: "absolute",
+          left: "-25%",
+          height: "100%",
+          width: "45%",
+          backgroundImage:
+            "linear-gradient(to left, rgba(251,251,251, .05), rgba(251,251,251, .3), rgba(251,251,251, .6), rgba(251,251,251, .3), rgba(251,251,251, .05))",
+          animation: `${loading} 1s infinite`
+        }}
+      />
+      &nbsp;
+    </Flex>
+  );
+};

--- a/packages/dev-frontend/src/setupTests.ts
+++ b/packages/dev-frontend/src/setupTests.ts
@@ -9,7 +9,7 @@ import { configure } from "@testing-library/dom";
 import { DisposableWalletProvider } from "./testUtils/DisposableWalletProvider";
 
 // Loading the Liquity store takes longer without Multicall
-configure({ asyncUtilTimeout: 2500 });
+configure({ asyncUtilTimeout: 5000 });
 
 const ethereum = new DisposableWalletProvider(
   "http://localhost:8545",


### PR DESCRIPTION
- Refreshes every 15 seconds
- Updates whenever the backend is mutated (write operations: approve lusd, create/cancel/claim bond)
- Optimistically renders a new bond when its created, then updates the unknown values when the backend refreshes
- Optimistically removes or claims a bond before waiting for the backend values to refresh