### PR TITLE
Buy & sell bLUSD within the frontend

### DIFF
--- a/packages/dev-frontend/src/components/Bonds/Bonds.tsx
+++ b/packages/dev-frontend/src/components/Bonds/Bonds.tsx
@@ -5,6 +5,7 @@ import { Actioning } from "./views/actioning/Actioning";
 import { Creating } from "./views/creating/Creating";
 import { InfoMessage } from "../InfoMessage";
 import { Container } from "theme-ui";
+import { Swapping } from "./views/swapping/Swapping";
 
 export const Bonds: React.FC = () => {
   const { view, hasFoundContracts } = useBondView();
@@ -29,6 +30,9 @@ export const Bonds: React.FC = () => {
     case "CREATING": {
       View = <Creating />;
       break;
+    }
+    case "SWAPPING": {
+      View = <Swapping />;
     }
   }
 

--- a/packages/dev-frontend/src/components/Bonds/context/BondViewContext.tsx
+++ b/packages/dev-frontend/src/components/Bonds/context/BondViewContext.tsx
@@ -38,6 +38,7 @@ export type BondViewContextType = {
   resetSimulatedMarketPrice: () => void;
   hasFoundContracts: boolean;
   inputToken: BLusdAmmTokenIndex;
+  isInputTokenApprovedWithBLusdAmm: boolean;
   getExpectedSwapOutput: (inputToken: BLusdAmmTokenIndex, inputAmount: Decimal) => Promise<Decimal>;
   swapTokens: (
     inputToken: BLusdAmmTokenIndex,

--- a/packages/dev-frontend/src/components/Bonds/context/BondViewContext.tsx
+++ b/packages/dev-frontend/src/components/Bonds/context/BondViewContext.tsx
@@ -8,7 +8,8 @@ import type {
   Stats,
   BondTransactionStatuses,
   ProtocolInfo,
-  OptimisticBond
+  OptimisticBond,
+  BLusdAmmTokenIndex
 } from "./transitions";
 import { PENDING_STATUS, CANCELLED_STATUS, CLAIMED_STATUS } from "../lexicon";
 import { Decimal } from "@liquity/lib-base";
@@ -36,6 +37,13 @@ export type BondViewContextType = {
   setSimulatedMarketPrice: (marketPrice: Decimal) => void;
   resetSimulatedMarketPrice: () => void;
   hasFoundContracts: boolean;
+  inputToken: BLusdAmmTokenIndex;
+  getExpectedSwapOutput: (inputToken: BLusdAmmTokenIndex, inputAmount: Decimal) => Promise<Decimal>;
+  swapTokens: (
+    inputToken: BLusdAmmTokenIndex,
+    inputAmount: Decimal,
+    minOutputAmount: Decimal
+  ) => Promise<void>;
 };
 
 export const BondViewContext = createContext<BondViewContextType | null>(null);

--- a/packages/dev-frontend/src/components/Bonds/context/BondViewProvider.tsx
+++ b/packages/dev-frontend/src/components/Bonds/context/BondViewProvider.tsx
@@ -11,8 +11,10 @@ import type {
   BondTransactionStatuses,
   CreateBondPayload,
   ProtocolInfo,
-  OptimisticBond
+  OptimisticBond,
+  SwapPayload
 } from "./transitions";
+import { BLusdAmmTokenIndex } from "./transitions";
 import { transitions } from "./transitions";
 import { Decimal } from "@liquity/lib-base";
 import { useLiquity } from "../../../hooks/LiquityContext";
@@ -56,11 +58,13 @@ export const BondViewProvider: React.FC = props => {
   const [simulatedProtocolInfo, setSimulatedProtocolInfo] = useState<ProtocolInfo>();
   const [isInfiniteBondApproved, setIsInfiniteBondApproved] = useState(false);
   const [isSynchronizing, setIsSynchronizing] = useState(true);
+  const [inputToken, setInputToken] = useState<BLusdAmmTokenIndex>(BLusdAmmTokenIndex.BLUSD);
   const [statuses, setStatuses] = useState<BondTransactionStatuses>({
     APPROVE: "IDLE",
     CREATE: "IDLE",
     CANCEL: "IDLE",
-    CLAIM: "IDLE"
+    CLAIM: "IDLE",
+    SWAP: "IDLE"
   });
   const [bLusdBalance, setBLusdBalance] = useState<Decimal>();
   const [lusdBalance, setLusdBalance] = useState<Decimal>();
@@ -247,6 +251,20 @@ export const BondViewProvider: React.FC = props => {
     [chickenBondManager, changeBondStatusToClaimed]
   );
 
+  const getExpectedSwapOutput = useCallback(
+    async (inputToken: BLusdAmmTokenIndex, inputAmount: Decimal) =>
+      bLusdAmm ? api.getExpectedSwapOutput(inputToken, inputAmount, bLusdAmm) : Decimal.ZERO,
+    [bLusdAmm]
+  );
+
+  const [swapTokens, swapStatus] = useTransaction(
+    async (inputToken: BLusdAmmTokenIndex, inputAmount: Decimal, minOutputAmount: Decimal) => {
+      await api.swapTokens(inputToken, inputAmount, minOutputAmount, bLusdAmm);
+      setShouldSynchronize(true);
+    },
+    [bLusdAmm]
+  );
+
   const selectedBond = useMemo(() => bonds?.find(bond => bond.id === selectedBondId), [
     bonds,
     selectedBondId
@@ -254,13 +272,20 @@ export const BondViewProvider: React.FC = props => {
 
   const dispatchEvent = useCallback(
     async (event: BondEvent, payload?: Payload) => {
-      if (!isValidEvent(viewRef.current, event)) return;
+      if (!isValidEvent(viewRef.current, event)) {
+        console.error("invalid event", event, payload, "in view", viewRef.current);
+        return;
+      }
 
       const nextView = transition(viewRef.current, event);
       setView(nextView);
 
       if (payload && "bondId" in payload && payload.bondId !== selectedBondId) {
         setSelectedBondId(payload.bondId);
+      }
+
+      if (payload && "inputToken" in payload && payload.inputToken !== inputToken) {
+        setInputToken(payload.inputToken);
       }
 
       const isCurrentViewEvent = (_view: BondView, _event: BondEvent) =>
@@ -281,6 +306,10 @@ export const BondViewProvider: React.FC = props => {
           }
           await cancelBond(selectedBond.id, selectedBond.deposit);
           await dispatchEvent("CANCEL_BOND_CONFIRMED");
+        } else if (isCurrentViewEvent("SWAPPING", "CONFIRM_PRESSED")) {
+          const { inputAmount, minOutputAmount } = payload as SwapPayload;
+          await swapTokens(inputToken, inputAmount, minOutputAmount);
+          await dispatchEvent("SWAP_CONFIRMED");
         } else if (isCurrentViewEvent("CLAIMING", "CONFIRM_PRESSED")) {
           if (selectedBond === undefined) {
             console.error(
@@ -295,7 +324,16 @@ export const BondViewProvider: React.FC = props => {
         console.error("dispatchEvent(), event handler failed\n\n", error);
       }
     },
-    [selectedBondId, approveInfiniteBond, createBond, cancelBond, claimBond, selectedBond]
+    [
+      selectedBondId,
+      approveInfiniteBond,
+      createBond,
+      cancelBond,
+      claimBond,
+      selectedBond,
+      swapTokens,
+      inputToken
+    ]
   );
 
   useEffect(() => {
@@ -304,9 +342,10 @@ export const BondViewProvider: React.FC = props => {
       APPROVE: approveStatus,
       CREATE: createStatus,
       CANCEL: cancelStatus,
-      CLAIM: claimStatus
+      CLAIM: claimStatus,
+      SWAP: swapStatus
     }));
-  }, [approveStatus, createStatus, cancelStatus, claimStatus]);
+  }, [approveStatus, createStatus, cancelStatus, claimStatus, swapStatus]);
 
   useEffect(() => {
     viewRef.current = view;
@@ -334,7 +373,10 @@ export const BondViewProvider: React.FC = props => {
     setSimulatedMarketPrice,
     resetSimulatedMarketPrice,
     simulatedProtocolInfo,
-    hasFoundContracts
+    hasFoundContracts,
+    inputToken,
+    getExpectedSwapOutput,
+    swapTokens
   };
 
   // @ts-ignore // TODO REMOVE

--- a/packages/dev-frontend/src/components/Bonds/context/api.ts
+++ b/packages/dev-frontend/src/components/Bonds/context/api.ts
@@ -1,5 +1,8 @@
 import { constants } from "ethers";
-import { CHICKEN_BOND_MANAGER_ADDRESS } from "@liquity/chicken-bonds/lusd/addresses";
+import {
+  CHICKEN_BOND_MANAGER_ADDRESS,
+  BLUSD_AMM_ADDRESS
+} from "@liquity/chicken-bonds/lusd/addresses";
 import type { BLUSDToken, BondNFT, ChickenBondManager } from "@liquity/chicken-bonds/lusd/types";
 import type { CurveCryptoSwap2ETH } from "@liquity/chicken-bonds/lusd/types/external";
 import type {
@@ -282,11 +285,10 @@ const getTokenBalance = async (account: string, token: BLUSDToken | LUSDToken): 
 const isInfiniteBondApproved = async (account: string, lusdToken: LUSDToken): Promise<boolean> => {
   const allowance = await lusdToken.allowance(account, CHICKEN_BOND_MANAGER_ADDRESS);
 
-  // TODO: what is going on?.. weird quirk in forked mainnet version
-  if (process.env.REACT_APP_DEMO_MODE === "true") {
-    return allowance._hex === "0xfffffffffffffffffffffffffffffffffffffffffffffffa9438a1d29cefffff";
-  }
-  return allowance.eq(constants.MaxUint256);
+  // Unlike bLUSD, LUSD doesn't explicitly handle infinite approvals, therefore the allowance will
+  // start to decrease from 2**64.
+  // However, it is practically impossible that it would decrease below 2**63.
+  return allowance.gt(constants.MaxInt256);
 };
 
 const approveInfiniteBond = async (lusdToken: LUSDToken | undefined) => {
@@ -362,6 +364,26 @@ const claimBond = async (
   }
 };
 
+const isTokenApprovedWithBLusdAmm = async (
+  account: string,
+  token: LUSDToken | BLUSDToken
+): Promise<boolean> => {
+  const allowance = await token.allowance(account, BLUSD_AMM_ADDRESS);
+
+  // Unlike bLUSD, LUSD doesn't explicitly handle infinite approvals, therefore the allowance will
+  // start to decrease from 2**64.
+  // However, it is practically impossible that it would decrease below 2**63.
+  return allowance.gt(constants.MaxInt256);
+};
+
+const approveTokenWithBLusdAmm = async (token: LUSDToken | BLUSDToken | undefined) => {
+  if (token === undefined) {
+    throw new Error("approveTokenWithBLusdAmm() failed: a dependency is null");
+  }
+
+  return (await token.approve(BLUSD_AMM_ADDRESS, constants.MaxUint256)).wait();
+};
+
 const getOtherToken = (thisToken: BLusdAmmTokenIndex) =>
   thisToken === BLusdAmmTokenIndex.BLUSD ? BLusdAmmTokenIndex.LUSD : BLusdAmmTokenIndex.BLUSD;
 
@@ -413,6 +435,8 @@ export const api = {
   createBond,
   cancelBond,
   claimBond,
+  isTokenApprovedWithBLusdAmm,
+  approveTokenWithBLusdAmm,
   getExpectedSwapOutput,
   swapTokens
 };

--- a/packages/dev-frontend/src/components/Bonds/context/transitions.ts
+++ b/packages/dev-frontend/src/components/Bonds/context/transitions.ts
@@ -4,8 +4,9 @@ type Idle = "IDLE";
 type Creating = "CREATING";
 type Cancelling = "CANCELLING";
 type Claiming = "CLAIMING";
+type Swapping = "SWAPPING";
 
-export type BondView = Idle | Creating | Cancelling | Claiming;
+export type BondView = Idle | Creating | Cancelling | Claiming | Swapping;
 
 /* UI events */
 type CreateBondPressed = "CREATE_BOND_PRESSED";
@@ -15,23 +16,27 @@ type ApprovePressed = "APPROVE_PRESSED";
 type ConfirmPressed = "CONFIRM_PRESSED";
 type CancelBondPressed = "CANCEL_BOND_PRESSED";
 type ClaimBondPressed = "CLAIM_BOND_PRESSED";
+type SwapPressed = "SWAP_PRESSED";
 
 /* On-chain events */
 type CreateBondConfirmed = "CREATE_BOND_CONFIRMED";
 type CancelBondConfirmed = "CANCEL_BOND_CONFIRMED";
 type ClaimBondConfirmed = "CLAIM_BOND_CONFIRMED";
+type SwapConfirmed = "SWAP_CONFIRMED";
 
 export type BondEvent =
   | CreateBondPressed
   | CancelBondPressed
   | ClaimBondPressed
+  | SwapPressed
   | ApprovePressed
   | ConfirmPressed
   | CancelPressed
   | BackPressed
   | CreateBondConfirmed
   | CancelBondConfirmed
-  | ClaimBondConfirmed;
+  | ClaimBondConfirmed
+  | SwapConfirmed;
 
 type BondEventTransitions = Record<BondView, Partial<Record<BondEvent, BondView>>>;
 
@@ -39,7 +44,8 @@ export const transitions: BondEventTransitions = {
   IDLE: {
     CREATE_BOND_PRESSED: "CREATING",
     CANCEL_BOND_PRESSED: "CANCELLING",
-    CLAIM_BOND_PRESSED: "CLAIMING"
+    CLAIM_BOND_PRESSED: "CLAIMING",
+    SWAP_PRESSED: "SWAPPING"
   },
   CREATING: {
     ABORT_PRESSED: "IDLE",
@@ -59,14 +65,34 @@ export const transitions: BondEventTransitions = {
     BACK_PRESSED: "IDLE",
     CONFIRM_PRESSED: "CANCELLING",
     CANCEL_BOND_CONFIRMED: "IDLE"
+  },
+  SWAPPING: {
+    ABORT_PRESSED: "IDLE",
+    BACK_PRESSED: "IDLE",
+    CONFIRM_PRESSED: "SWAPPING",
+    SWAP_CONFIRMED: "IDLE"
   }
 };
+
+export enum BLusdAmmTokenIndex {
+  BLUSD,
+  LUSD
+}
 
 export type CreateBondPayload = { deposit: Decimal };
 
 export type SelectBondPayload = { bondId: string };
 
-export type Payload = CreateBondPayload | SelectBondPayload;
+export type SwapPressedPayload = {
+  inputToken: BLusdAmmTokenIndex;
+};
+
+export type SwapPayload = {
+  inputAmount: Decimal;
+  minOutputAmount: Decimal;
+};
+
+export type Payload = CreateBondPayload | SelectBondPayload | SwapPressedPayload | SwapPayload;
 
 export type BondStatus = "NON_EXISTENT" | "PENDING" | "CANCELLED" | "CLAIMED";
 
@@ -123,6 +149,6 @@ export type ProtocolInfo = {
 };
 
 export type TransactionStatus = "IDLE" | "PENDING" | "CONFIRMED" | "FAILED";
-export type BondTransaction = "APPROVE" | "CREATE" | "CANCEL" | "CLAIM";
+export type BondTransaction = "APPROVE" | "CREATE" | "CANCEL" | "CLAIM" | "SWAP";
 
 export type BondTransactionStatuses = Record<BondTransaction, TransactionStatus>;

--- a/packages/dev-frontend/src/components/Bonds/context/transitions.ts
+++ b/packages/dev-frontend/src/components/Bonds/context/transitions.ts
@@ -69,6 +69,7 @@ export const transitions: BondEventTransitions = {
   SWAPPING: {
     ABORT_PRESSED: "IDLE",
     BACK_PRESSED: "IDLE",
+    APPROVE_PRESSED: "SWAPPING",
     CONFIRM_PRESSED: "SWAPPING",
     SWAP_CONFIRMED: "IDLE"
   }
@@ -149,6 +150,14 @@ export type ProtocolInfo = {
 };
 
 export type TransactionStatus = "IDLE" | "PENDING" | "CONFIRMED" | "FAILED";
-export type BondTransaction = "APPROVE" | "CREATE" | "CANCEL" | "CLAIM" | "SWAP";
+
+export type BondTransaction =
+  | "APPROVE"
+  | "CREATE"
+  | "CANCEL"
+  | "CLAIM"
+  | "APPROVE_AMM_LUSD"
+  | "APPROVE_AMM_BLUSD"
+  | "SWAP";
 
 export type BondTransactionStatuses = Record<BondTransaction, TransactionStatus>;

--- a/packages/dev-frontend/src/components/Bonds/views/idle/Bond.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/idle/Bond.tsx
@@ -1,12 +1,12 @@
-import { Card, Flex, Button, Link, Image, ThemeUIStyleObject } from "theme-ui";
+import { Card, Flex, Button, Image, ThemeUIStyleObject } from "theme-ui";
 import { EventType, HorizontalTimeline } from "../../../HorizontalTimeline";
 import { nfts } from "../../context/BondViewProvider";
 import { Record } from "../../Record";
 import { Actions } from "./actions/Actions";
-import type { Bond as BondType } from "../../context/transitions";
+import { BLusdAmmTokenIndex, Bond as BondType, SwapPressedPayload } from "../../context/transitions";
 import { Label, SubLabel } from "../../../HorizontalTimeline";
 import * as l from "../../lexicon";
-import { statuses } from "../../context/BondViewContext";
+import { statuses, useBondView } from "../../context/BondViewContext";
 
 const getBondEvents = (bond: BondType): EventType[] => {
   return [
@@ -64,6 +64,11 @@ type BondProps = { bond: BondType; style?: ThemeUIStyleObject };
 
 export const Bond: React.FC<BondProps> = ({ bond, style }) => {
   const events = getBondEvents(bond);
+  const { dispatchEvent } = useBondView();
+
+  const handleSellBLusdPressed = () => {
+    dispatchEvent("SWAP_PRESSED", { inputToken: BLusdAmmTokenIndex.BLUSD } as SwapPressedPayload);
+  };
 
   return (
     <Flex
@@ -161,15 +166,8 @@ export const Bond: React.FC<BondProps> = ({ bond, style }) => {
             </Flex>
             {bond.status === "PENDING" && <Actions bondId={bond.id} />}
             {bond.status !== "PENDING" && bond.status === "CLAIMED" && (
-              <Button variant="outline" sx={{ height: "44px" }}>
-                <Link
-                  variant="outline"
-                  href="https://curve.fi"
-                  sx={{ textDecoration: "none" }}
-                  target="external"
-                >
-                  Sell bLUSD
-                </Link>
+              <Button variant="outline" sx={{ height: "44px" }} onClick={handleSellBLusdPressed}>
+                Sell bLUSD
               </Button>
             )}
           </Flex>

--- a/packages/dev-frontend/src/components/Bonds/views/idle/Idle.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/idle/Idle.tsx
@@ -6,34 +6,46 @@ import { useBondView } from "../../context/BondViewContext";
 import { BONDS } from "../../lexicon";
 import { InfoIcon } from "../../../InfoIcon";
 import { LUSD_OVERRIDE_ADDRESS } from "@liquity/chicken-bonds/lusd/addresses";
+import { BLusdAmmTokenIndex, SwapPressedPayload } from "../../context/transitions";
 
 export const Idle: React.FC = () => {
-  const { dispatchEvent, bonds, isSynchronizing, getLusdFromFaucet, lusdBalance } = useBondView();
+  const { dispatchEvent, bonds, getLusdFromFaucet, lusdBalance } = useBondView();
 
   const hasBonds = bonds !== undefined && bonds.length > 0;
 
   const showLusdFaucet = LUSD_OVERRIDE_ADDRESS !== null && lusdBalance?.eq(0);
 
+  const handleBuyBLusdPressed = () =>
+    dispatchEvent("SWAP_PRESSED", { inputToken: BLusdAmmTokenIndex.LUSD } as SwapPressedPayload);
+
+  const handleSellBLusdPressed = () =>
+    dispatchEvent("SWAP_PRESSED", { inputToken: BLusdAmmTokenIndex.BLUSD } as SwapPressedPayload);
+
   return (
     <>
-      {showLusdFaucet && (
-        <Flex variant="layout.actions" mt={4}>
+      <Flex variant="layout.actions" mt={4}>
+        <Button variant="outline" onClick={handleBuyBLusdPressed}>
+          Buy bLUSD
+        </Button>
+
+        <Button variant="outline" onClick={handleSellBLusdPressed}>
+          Sell bLUSD
+        </Button>
+
+        {showLusdFaucet && (
           <Button variant="outline" onClick={() => getLusdFromFaucet()}>
             Get 10k LUSD
           </Button>
-        </Flex>
-      )}
-      {hasBonds && (
-        <>
-          <Flex mt={4} variant="layout.actions">
-            <Button variant="primary" onClick={() => dispatchEvent("CREATE_BOND_PRESSED")}>
-              Create another bond
-            </Button>
-          </Flex>
-          <BondList />
-        </>
-      )}
-      {!hasBonds && !isSynchronizing && (
+        )}
+
+        {hasBonds && (
+          <Button variant="primary" onClick={() => dispatchEvent("CREATE_BOND_PRESSED")}>
+            Create another bond
+          </Button>
+        )}
+      </Flex>
+
+      {!hasBonds && (
         <Card>
           <Heading>
             <Flex>
@@ -56,6 +68,8 @@ export const Idle: React.FC = () => {
           </Box>
         </Card>
       )}
+
+      {hasBonds && <BondList />}
     </>
   );
 };

--- a/packages/dev-frontend/src/components/Bonds/views/idle/OptimisticBond.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/idle/OptimisticBond.tsx
@@ -1,11 +1,16 @@
-import { Card, Flex, Button, Link, Image, ThemeUIStyleObject } from "theme-ui";
+import { Card, Flex, Button, Image, ThemeUIStyleObject } from "theme-ui";
 import { EventType, HorizontalTimeline, UNKNOWN_DATE } from "../../../HorizontalTimeline";
 import { nfts } from "../../context/BondViewProvider";
 import { Record } from "../../Record";
 import { Actions } from "./actions/Actions";
-import type { OptimisticBond as OptimisticBondType } from "../../context/transitions";
+import {
+  BLusdAmmTokenIndex,
+  OptimisticBond as OptimisticBondType,
+  SwapPressedPayload
+} from "../../context/transitions";
 import { Label, SubLabel } from "../../../HorizontalTimeline";
 import * as l from "../../lexicon";
+import { useBondView } from "../../context/BondViewContext";
 
 const getBondEvents = (bond: OptimisticBondType): EventType[] => {
   return [
@@ -61,6 +66,11 @@ type BondProps = { bond: OptimisticBondType; style?: ThemeUIStyleObject };
 
 export const OptimisticBond: React.FC<BondProps> = ({ bond, style }) => {
   const events = getBondEvents(bond);
+  const { dispatchEvent } = useBondView();
+
+  const handleSellBLusdPressed = () => {
+    dispatchEvent("SWAP_PRESSED", { inputToken: BLusdAmmTokenIndex.BLUSD } as SwapPressedPayload);
+  };
 
   return (
     <Flex
@@ -157,15 +167,8 @@ export const OptimisticBond: React.FC<BondProps> = ({ bond, style }) => {
             </Flex>
             {bond.status === "PENDING" && <Actions bondId={bond.id} disabled />}
             {bond.status !== "PENDING" && bond.status === "CLAIMED" && (
-              <Button variant="outline" sx={{ height: "44px" }}>
-                <Link
-                  variant="outline"
-                  href="https://curve.fi"
-                  sx={{ textDecoration: "none" }}
-                  target="external"
-                >
-                  Sell bLUSD
-                </Link>
+              <Button variant="outline" sx={{ height: "44px" }} onClick={handleSellBLusdPressed}>
+                Sell bLUSD
               </Button>
             )}
           </Flex>

--- a/packages/dev-frontend/src/components/Bonds/views/swapping/SwapPane.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/swapping/SwapPane.tsx
@@ -1,0 +1,121 @@
+import { Decimal } from "@liquity/lib-base";
+import React, { useEffect, useState } from "react";
+import { Flex, Button, Spinner, Heading, Close } from "theme-ui";
+import { Icon } from "../../../Icon";
+import { DisabledEditableRow, EditableRow, StaticRow } from "../../../Trove/Editor";
+import { useBondView } from "../../context/BondViewContext";
+import { BLusdAmmTokenIndex, SwapPayload } from "../../context/transitions";
+
+const tokenSymbol: Record<BLusdAmmTokenIndex, string> = {
+  [BLusdAmmTokenIndex.BLUSD]: "bLUSD",
+  [BLusdAmmTokenIndex.LUSD]: "LUSD"
+};
+
+const outputToken: Record<BLusdAmmTokenIndex, BLusdAmmTokenIndex> = {
+  [BLusdAmmTokenIndex.BLUSD]: BLusdAmmTokenIndex.LUSD,
+  [BLusdAmmTokenIndex.LUSD]: BLusdAmmTokenIndex.BLUSD
+};
+
+export const SwapPane: React.FC = () => {
+  const {
+    dispatchEvent,
+    statuses,
+    inputToken,
+    lusdBalance,
+    bLusdBalance,
+    getExpectedSwapOutput
+  } = useBondView();
+  const inputAmountEditingState = useState<string>();
+  const maxInputAmount =
+    (inputToken === BLusdAmmTokenIndex.BLUSD ? bLusdBalance : lusdBalance) ?? Decimal.ZERO;
+  const [inputAmount, setInputAmount] = useState<Decimal>(maxInputAmount);
+  const [outputAmount, setOutputAmount] = useState<Decimal>(Decimal.ZERO);
+  const [exchangeRate, setExchangeRate] = useState<Decimal>(Decimal.ZERO);
+
+  const isProcessingTransaction = statuses.SWAP === "PENDING";
+
+  const handleDismiss = () => {
+    dispatchEvent("ABORT_PRESSED");
+  };
+
+  const handleConfirmPressed = () => {
+    dispatchEvent("CONFIRM_PRESSED", { inputAmount, minOutputAmount: Decimal.ZERO } as SwapPayload);
+  };
+
+  const handleBackPressed = () => {
+    dispatchEvent("BACK_PRESSED");
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const timeoutId = setTimeout(async () => {
+      const expectedOutputAmount = await getExpectedSwapOutput(inputToken, inputAmount);
+      if (cancelled) return;
+      setOutputAmount(expectedOutputAmount);
+      setExchangeRate(expectedOutputAmount.div(inputAmount));
+    }, 200);
+
+    return () => {
+      clearTimeout(timeoutId);
+      cancelled = true;
+    };
+  }, [inputToken, inputAmount, getExpectedSwapOutput]);
+
+  return (
+    <>
+      <Heading as="h2" sx={{ pt: 2, pb: 3, px: 2 }}>
+        <Flex sx={{ justifyContent: "center" }}>Sell bLUSD</Flex>
+        <Close
+          onClick={handleDismiss}
+          sx={{
+            position: "absolute",
+            right: "24px",
+            top: "24px"
+          }}
+        />
+      </Heading>
+
+      <EditableRow
+        label="Sell"
+        inputId="swap-input-amount"
+        amount={inputAmount.prettify(2)}
+        unit={tokenSymbol[inputToken]}
+        editingState={inputAmountEditingState}
+        editedAmount={inputAmount.toString()}
+        setEditedAmount={amount => setInputAmount(Decimal.min(maxInputAmount, Decimal.from(amount)))}
+        maxAmount={maxInputAmount.toString()}
+        maxedOut={inputAmount.eq(maxInputAmount)}
+      />
+
+      <Flex sx={{ justifyContent: "center", mb: 3 }}>
+        <Icon name="arrow-down" size="lg" />
+      </Flex>
+
+      <DisabledEditableRow
+        label="Buy"
+        inputId="swap-output-amount"
+        amount={outputAmount.prettify(2)}
+        unit={tokenSymbol[outputToken[inputToken]]}
+      />
+
+      <StaticRow
+        label="Exchange rate"
+        inputId="swap-exchange-rate"
+        amount={exchangeRate.prettify(4)}
+        unit={`${tokenSymbol[inputToken]}:${tokenSymbol[outputToken[inputToken]]}`}
+      />
+
+      <Flex variant="layout.actions">
+        <Button variant="cancel" onClick={handleBackPressed} disabled={isProcessingTransaction}>
+          Back
+        </Button>
+
+        <Button variant="primary" onClick={handleConfirmPressed} disabled={isProcessingTransaction}>
+          {!isProcessingTransaction && <>Confirm</>}
+          {isProcessingTransaction && <Spinner size="28px" sx={{ color: "white" }} />}
+        </Button>
+      </Flex>
+    </>
+  );
+};

--- a/packages/dev-frontend/src/components/Bonds/views/swapping/SwapPane.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/swapping/SwapPane.tsx
@@ -91,7 +91,9 @@ export const SwapPane: React.FC = () => {
   return (
     <>
       <Heading as="h2" sx={{ pt: 2, pb: 3, px: 2 }}>
-        <Flex sx={{ justifyContent: "center" }}>Sell bLUSD</Flex>
+        <Flex sx={{ justifyContent: "center" }}>
+          {inputToken === BLusdAmmTokenIndex.BLUSD ? <>Sell</> : <>Buy</>} bLUSD
+        </Flex>
         <Close
           onClick={handleDismiss}
           sx={{

--- a/packages/dev-frontend/src/components/Bonds/views/swapping/Swapping.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/swapping/Swapping.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { ReactModal } from "../../../ReactModal";
+import { useBondView } from "../../context/BondViewContext";
+import { SwapPane } from "./SwapPane";
+
+export const Swapping: React.FC = () => {
+  const { dispatchEvent } = useBondView();
+
+  const handleDismiss = () => {
+    dispatchEvent("ABORT_PRESSED");
+  };
+
+  return (
+    <ReactModal onDismiss={handleDismiss}>
+      <SwapPane />
+    </ReactModal>
+  );
+};

--- a/packages/dev-frontend/src/components/Icon.tsx
+++ b/packages/dev-frontend/src/components/Icon.tsx
@@ -27,7 +27,8 @@ import {
   faPen,
   faHandPaper,
   faHeartbeat,
-  faBars
+  faBars,
+  faArrowDown
 } from "@fortawesome/free-solid-svg-icons";
 import { faClipboard, faQuestionCircle } from "@fortawesome/free-regular-svg-icons";
 import { FontAwesomeIcon, FontAwesomeIconProps } from "@fortawesome/react-fontawesome";
@@ -61,7 +62,8 @@ library.add(
   faHandPaper,
   faHeartbeat,
   faBars,
-  faQuestionCircle
+  faQuestionCircle,
+  faArrowDown
 );
 
 const getIcon = (name: IconName): IconProp => {


### PR DESCRIPTION
Adds the ability to swap bLUSD back and forth with LUSD without having to turn to the Curve frontend (which doesn't support testnets, preventing us from fully testing all aspects of LUSD Chicken Bonds).

### Still missing
Slippage handling. Currently, any amount of slippage is tolerated.
Ability to add/manage liquidity.

### Potential improvement
We might want to show price impact?

### Screenshots

#### Two new actions added to Bond page:

<img width="896" alt="image" src="https://user-images.githubusercontent.com/60874270/187618510-6b99b672-ed0e-445a-b921-9362826b1d2d.png">

#### Swapping in action:

<img width="662" alt="image" src="https://user-images.githubusercontent.com/60874270/187618789-a3e1acad-526b-48ff-b8d9-0050590c816c.png">

#### Error case: insufficient balance

<img width="662" alt="image" src="https://user-images.githubusercontent.com/60874270/187619168-cb481a96-6dcf-42e1-bdab-59528fb79f39.png">
