### PR TITLE
Bonds UI: Use real NFT images 

### DIFF
--- a/packages/dev-frontend/src/components/Bonds/BondsTable.tsx
+++ b/packages/dev-frontend/src/components/Bonds/BondsTable.tsx
@@ -105,8 +105,8 @@ export const BondsTable: React.FC = () => {
             {Line(5)}
 
             {pendingBonds.map((bond, idx) => {
-              const breakEvenDays = (bond.breakEvenTime - Date.now()) / 1000 / 60 / 60 / 24;
-              const rebondDays = (bond.rebondTime - Date.now()) / 1000 / 60 / 60 / 24;
+              const breakEvenDays = (bond.breakEvenTime.getTime() - Date.now()) / 1000 / 60 / 60 / 24;
+              const rebondDays = (bond.rebondTime.getTime() - Date.now()) / 1000 / 60 / 60 / 24;
               return (
                 <React.Fragment key={idx}>
                   <Text>{bond.deposit.shorten()} LUSD</Text>

--- a/packages/dev-frontend/src/components/Bonds/Record.tsx
+++ b/packages/dev-frontend/src/components/Bonds/Record.tsx
@@ -17,7 +17,11 @@ export const Record: React.FC<RecordType> = ({ name, description, value, type, s
         {name} <InfoIcon size="xs" tooltip={<Card variant="tooltip">{description}</Card>} />
       </Flex>
       <Text as="h3" sx={{ display: "flex", justifyContent: "center" }}>
-        {value ? <Text sx={{ fontWeight: "400" }}>{value}</Text> : <Placeholder />}
+        {value ? (
+          <Text sx={{ fontWeight: "400" }}>{value}</Text>
+        ) : (
+          <Placeholder style={{ mx: "20%" }} />
+        )}
         &nbsp;
         {value && <Text sx={{ fontWeight: "light", opacity: 0.8 }}>{type}</Text>}
       </Text>

--- a/packages/dev-frontend/src/components/Bonds/context/BondViewProvider.tsx
+++ b/packages/dev-frontend/src/components/Bonds/context/BondViewProvider.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useCallback, useEffect, useRef, useMemo } from "react";
 import { BondViewContext, BondViewContextType } from "./BondViewContext";
 import type {
-  BondStatus,
   Stats,
   BondView,
   BondEvent,
@@ -35,12 +34,7 @@ const transition = (view: BondView, event: BondEvent): BondView => {
   return nextView;
 };
 
-export const nfts: Record<BondStatus, string> = {
-  PENDING: "./bonds/egg-nft.png",
-  CANCELLED: "./bonds/bond-cancelled-dark.png",
-  CLAIMED: "./bonds/example-nft-light.gif",
-  NON_EXISTENT: ""
-};
+export const EXAMPLE_NFT = "./bonds/egg-nft.png";
 
 export const BondViewProvider: React.FC = props => {
   const { children } = props;
@@ -341,7 +335,7 @@ export const BondViewProvider: React.FC = props => {
   window.bonds = provider;
 
   // If contracts don't load it means they're not deployed, we shouldn't block the app from running in this case
-  if (bonds === undefined && hasFoundContracts) return <AppLoader />;
+  if (protocolInfo === undefined && hasFoundContracts) return <AppLoader />;
 
   return <BondViewContext.Provider value={provider}>{children}</BondViewContext.Provider>;
 };

--- a/packages/dev-frontend/src/components/Bonds/context/BondViewProvider.tsx
+++ b/packages/dev-frontend/src/components/Bonds/context/BondViewProvider.tsx
@@ -216,7 +216,11 @@ export const BondViewProvider: React.FC = props => {
             protocolInfo.claimBondFee,
             protocolInfo.alphaAccrualFactor
           );
-          setSimulatedProtocolInfo({ ...protocolInfo, ...simulatedProtocolInfo });
+          setSimulatedProtocolInfo({
+            ...protocolInfo,
+            ...simulatedProtocolInfo,
+            simulatedMarketPrice: protocolInfo.simulatedMarketPrice
+          });
         }
 
         setBLusdBalance(bLusdBalance);

--- a/packages/dev-frontend/src/components/Bonds/context/api.ts
+++ b/packages/dev-frontend/src/components/Bonds/context/api.ts
@@ -20,8 +20,13 @@ import {
   milliseconds,
   toFloat,
   getReturn,
-  getTokenUri
+  getTokenUri,
+  getBreakEvenDays,
+  getFutureBLusdAccrualFactor,
+  getFutureDateByDays,
+  getRebondDays
 } from "../utils";
+import { UNKNOWN_DATE } from "../../HorizontalTimeline";
 
 type Maybe<T> = T | undefined;
 
@@ -72,26 +77,29 @@ const getAccountBonds = async (
       const bondAgeInDays = getBondAgeInDays(startTime);
       const rebondDays = getRebondDays(alphaAccrualFactor, marketPricePremium, claimBondFee);
       const breakEvenDays = getBreakEvenDays(alphaAccrualFactor, marketPricePremium, claimBondFee);
+      const rebondAccrual =
+        rebondDays === Decimal.INFINITY
+          ? Decimal.INFINITY
+          : getFutureBLusdAccrualFactor(floorPrice, rebondDays, alphaAccrualFactor).mul(deposit);
+      const breakEvenAccrual =
+        breakEvenDays === Decimal.INFINITY
+          ? Decimal.INFINITY
+          : getFutureBLusdAccrualFactor(floorPrice, breakEvenDays, alphaAccrualFactor).mul(deposit);
 
-      const rebondAccrual = getFutureBLusdAccrualFactor(
-        floorPrice,
-        rebondDays,
-        alphaAccrualFactor
-      ).mul(deposit);
-      const breakEvenAccrual = getFutureBLusdAccrualFactor(
-        floorPrice,
-        breakEvenDays,
-        alphaAccrualFactor
-      ).mul(deposit);
-
-      const breakEvenTime = getFutureTimeByDays(toFloat(breakEvenDays) - bondAgeInDays);
-      const rebondTime = getFutureTimeByDays(toFloat(rebondDays) - bondAgeInDays);
+      const breakEvenTime =
+        breakEvenDays === Decimal.INFINITY
+          ? UNKNOWN_DATE
+          : getFutureDateByDays(toFloat(breakEvenDays) - bondAgeInDays);
+      const rebondTime =
+        breakEvenDays === Decimal.INFINITY
+          ? UNKNOWN_DATE
+          : getFutureDateByDays(toFloat(rebondDays) - bondAgeInDays);
       const marketValue = decimalify(bondAccrueds[idx]).mul(marketPrice);
 
       // Accrued bLUSD is 0 for cancelled/claimed bonds
-      const claimNowReturn = accrued.isZero ? "0" : getReturn(accrued, deposit, marketPrice);
-      const rebondReturn = accrued.isZero ? "0" : getReturn(rebondAccrual, deposit, marketPrice);
-      const rebondRoi = accrued.isZero ? Decimal.ZERO : Decimal.from(rebondReturn).div(deposit);
+      const claimNowReturn = accrued.isZero ? 0 : getReturn(accrued, deposit, marketPrice);
+      const rebondReturn = accrued.isZero ? 0 : getReturn(rebondAccrual, deposit, marketPrice);
+      const rebondRoi = rebondReturn / toFloat(deposit);
 
       return [
         ...accumulator,
@@ -119,47 +127,6 @@ const getAccountBonds = async (
   return bonds;
 };
 
-const getBreakEvenDays = (
-  alphaAccrualFactor: Decimal,
-  marketPricePremium: Decimal,
-  claimBondFee: Decimal
-): Decimal => {
-  return alphaAccrualFactor.div(marketPricePremium.mul(Decimal.ONE.sub(claimBondFee)).sub(1));
-};
-
-const getFutureBLusdAccrualFactor = (
-  floorPrice: Decimal,
-  daysInFuture: Decimal,
-  alphaAccrualFactor: Decimal,
-  bondAgeInDays = Decimal.ZERO
-): Decimal => {
-  const duration = daysInFuture.sub(bondAgeInDays);
-  return Decimal.ONE.div(floorPrice).mul(duration.div(duration.add(alphaAccrualFactor)));
-};
-
-const getRebondDays = (
-  alphaAccrualFactor: Decimal,
-  marketPricePremium: Decimal,
-  claimBondFee: Decimal
-): Decimal => {
-  const sqrt = Decimal.from(
-    Math.sqrt(parseFloat(Decimal.ONE.sub(claimBondFee).mul(marketPricePremium).toString()))
-  );
-  const dividend = Decimal.ONE.add(sqrt);
-  const divisor = Decimal.ONE.sub(claimBondFee).mul(marketPricePremium).gt(1)
-    ? Decimal.ONE.sub(claimBondFee).mul(marketPricePremium).sub(1)
-    : Decimal.ONE;
-  return alphaAccrualFactor.mul(dividend.div(divisor));
-};
-
-const daysToMilliseconds = (days: number): number => {
-  return days * 24 * 60 * 60 * 1000;
-};
-
-const getFutureTimeByDays = (days: number): number => {
-  return Math.round(Date.now() + daysToMilliseconds(days));
-};
-
 export const _getProtocolInfo = (
   marketPrice: Decimal,
   floorPrice: Decimal,
@@ -170,9 +137,9 @@ export const _getProtocolInfo = (
   const hasMarketPremium = marketPrice.gt(floorPrice.add(claimBondFee));
 
   const breakEvenDays = getBreakEvenDays(alphaAccrualFactor, marketPricePremium, claimBondFee);
-  const breakEvenTime = getFutureTimeByDays(toFloat(breakEvenDays));
+  const breakEvenTime = getFutureDateByDays(toFloat(breakEvenDays));
   const rebondDays = getRebondDays(alphaAccrualFactor, marketPricePremium, claimBondFee);
-  const rebondTime = getFutureTimeByDays(toFloat(rebondDays));
+  const rebondTime = getFutureDateByDays(toFloat(rebondDays));
   const breakEvenAccrualFactor = getFutureBLusdAccrualFactor(
     floorPrice,
     breakEvenDays,
@@ -192,8 +159,7 @@ export const _getProtocolInfo = (
     breakEvenAccrualFactor,
     rebondAccrualFactor,
     breakEvenDays,
-    rebondDays,
-    simulatedMarketPrice: marketPrice
+    rebondDays
   };
 };
 
@@ -204,17 +170,33 @@ const getProtocolInfo = async (
   reserveSize: Decimal
 ): Promise<ProtocolInfo> => {
   const bLusdSupply = decimalify(await bLusdToken.totalSupply());
-  const marketPrice = Decimal.ONE.div(decimalify(await bLusdAmm.price_oracle())).add(
-    0.05
-  ); /* TODO REMOVE 0.05 */
+  const marketPrice = Decimal.ONE.div(decimalify(await bLusdAmm.price_oracle()));
   const fairPrice = marketPrice.mul(1.1); /* TODO: use real formula */
   const floorPrice = reserveSize.eq(0) ? Decimal.ONE : reserveSize.div(bLusdSupply);
   const claimBondFee = decimalify(await chickenBondManager.CHICKEN_IN_AMM_FEE());
   const alphaAccrualFactor = decimalify(await chickenBondManager.accrualParameter()).div(
     24 * 60 * 60
   );
-
   const {
+    marketPricePremium,
+    breakEvenTime,
+    rebondTime,
+    hasMarketPremium,
+    breakEvenAccrualFactor,
+    rebondAccrualFactor,
+    breakEvenDays,
+    rebondDays
+  } = _getProtocolInfo(marketPrice, floorPrice, claimBondFee, alphaAccrualFactor);
+
+  const simulatedMarketPrice = hasMarketPremium ? marketPrice : floorPrice.mul(1.1);
+
+  return {
+    bLusdSupply,
+    marketPrice,
+    fairPrice,
+    floorPrice,
+    claimBondFee,
+    alphaAccrualFactor,
     marketPricePremium,
     breakEvenTime,
     rebondTime,
@@ -224,24 +206,6 @@ const getProtocolInfo = async (
     breakEvenDays,
     rebondDays,
     simulatedMarketPrice
-  } = _getProtocolInfo(marketPrice, floorPrice, claimBondFee, alphaAccrualFactor);
-
-  return {
-    bLusdSupply,
-    marketPrice,
-    fairPrice,
-    floorPrice,
-    claimBondFee,
-    alphaAccrualFactor,
-    simulatedMarketPrice,
-    marketPricePremium,
-    breakEvenTime,
-    rebondTime,
-    hasMarketPremium,
-    breakEvenAccrualFactor,
-    rebondAccrualFactor,
-    breakEvenDays,
-    rebondDays
   };
 };
 
@@ -296,7 +260,7 @@ const isInfiniteBondApproved = async (account: string, lusdToken: LUSDToken): Pr
   return allowance.eq(constants.MaxUint256);
 };
 
-const approveInfiniteBond = async (lusdToken: LUSDToken | undefined) => {
+const approveInfiniteBond = async (lusdToken: LUSDToken | undefined): Promise<void> => {
   if (lusdToken === undefined) throw new Error("approveInfiniteBond() failed: a dependency is null");
   console.log("approveInfiniteBond() started");
   try {
@@ -369,13 +333,49 @@ const claimBond = async (
   }
 };
 
-export const api = {
+export type BondsApi = {
+  getAccountBonds: (
+    account: string,
+    bondNft: BondNFT,
+    chickenBondManager: ChickenBondManager,
+    marketPrice: Decimal,
+    alphaAccrualFactor: Decimal,
+    marketPricePremium: Decimal,
+    claimBondFee: Decimal,
+    floorPrice: Decimal
+  ) => Promise<Bond[]>;
+  getStats: (bondNft: BondNFT) => Promise<Stats>;
+  getTreasury: (chickenBondManager: ChickenBondManager) => Promise<Treasury>;
+  getTokenBalance: (account: string, token: BLUSDToken | LUSDToken) => Promise<Decimal>;
+  getProtocolInfo: (
+    bLusdToken: BLUSDToken,
+    bLusdAmm: CurveCryptoSwap2ETH,
+    chickenBondManager: ChickenBondManager,
+    reserveSize: Decimal
+  ) => Promise<ProtocolInfo>;
+  approveInfiniteBond: (lusdToken: LUSDToken | undefined) => Promise<void>;
+  isInfiniteBondApproved: (account: string, lusdToken: LUSDToken) => Promise<boolean>;
+  createBond: (
+    lusdAmount: Decimal,
+    chickenBondManager: ChickenBondManager | undefined
+  ) => Promise<BondCreatedEventObject>;
+  cancelBond: (
+    bondId: string,
+    minimumLusd: Decimal,
+    chickenBondManager: ChickenBondManager | undefined
+  ) => Promise<BondCancelledEventObject>;
+  claimBond: (
+    bondId: string,
+    chickenBondManager: ChickenBondManager | undefined
+  ) => Promise<BondClaimedEventObject>;
+};
+
+export const api: BondsApi = {
   getAccountBonds,
   getStats,
   getTreasury,
   getTokenBalance,
   getProtocolInfo,
-  getFutureBLusdAccrualFactor,
   approveInfiniteBond,
   isInfiniteBondApproved,
   createBond,

--- a/packages/dev-frontend/src/components/Bonds/context/transitions.ts
+++ b/packages/dev-frontend/src/components/Bonds/context/transitions.ts
@@ -80,12 +80,12 @@ export type Bond = {
   accrued: Decimal;
   breakEvenAccrual: Decimal;
   rebondAccrual: Decimal;
-  breakEvenTime: number;
-  rebondTime: number;
+  breakEvenTime: Date;
+  rebondTime: Date;
   marketValue: Decimal;
-  rebondReturn: string;
-  rebondRoi: Decimal;
-  claimNowReturn: string;
+  rebondReturn: number;
+  rebondRoi: number;
+  claimNowReturn: number;
 };
 
 export type OptimisticBond = Pick<Bond, "id" | "deposit" | "startTime" | "status">;
@@ -112,8 +112,8 @@ export type ProtocolInfo = {
   claimBondFee: Decimal;
   alphaAccrualFactor: Decimal;
   marketPricePremium: Decimal;
-  breakEvenTime: number;
-  rebondTime: number;
+  breakEvenTime: Date;
+  rebondTime: Date;
   hasMarketPremium: boolean;
   simulatedMarketPrice: Decimal;
   breakEvenAccrualFactor: Decimal;

--- a/packages/dev-frontend/src/components/Bonds/utils.ts
+++ b/packages/dev-frontend/src/components/Bonds/utils.ts
@@ -10,21 +10,21 @@ const numberify = (bigNumber: BigNumber): number => bigNumber.toNumber();
 const decimalify = (bigNumber: BigNumber): Decimal =>
   Decimal.fromBigNumberString(bigNumber.toHexString());
 
-const secondsToDays = (seconds: number) => seconds / 60 / 60 / 24;
+const percentify = (fraction: number): number => fraction * 100;
 
-const daysToMilliseconds = (days: number) => days * 60 * 60 * 24 * 1000;
+const secondsToDays = (seconds: number): number => seconds / 60 / 60 / 24;
+
+const daysToMilliseconds = (days: number): number => days * 60 * 60 * 24 * 1000;
 
 const getBondAgeInDays = (startTime: number): number =>
   secondsToDays((Date.now() - startTime) / 1000);
 
 const dateWithoutHours = (timestamp: number) => new Date(new Date(timestamp).toDateString());
 
-const getReturn = (accrued: Decimal, deposit: Decimal, marketPrice: Decimal): string => {
+// Decimal type doesn't support negatives so use number instead
+const getReturn = (accrued: Decimal, deposit: Decimal, marketPrice: Decimal): number => {
   const accruedLusdValue = accrued.mul(marketPrice);
-  if (accruedLusdValue.lt(deposit)) {
-    return (parseFloat(accruedLusdValue.toString()) - parseFloat(deposit.toString())).toFixed(2);
-  }
-  return parseFloat(accruedLusdValue.sub(deposit).toString()).toFixed(2);
+  return parseFloat(accruedLusdValue.toString()) - parseFloat(deposit.toString());
 };
 
 const getTokenUri = (encodedTokenUri: string): string => {
@@ -32,13 +32,51 @@ const getTokenUri = (encodedTokenUri: string): string => {
   const dataStartIndex = encodedTokenUri.indexOf("base64,") + "base64,".length;
   if (dataStartIndex === -1) return "TODO:"; // TODO: should we render an error image?
 
-  const hack = atob(encodedTokenUri.slice(dataStartIndex)).replace(
-    `"background_color":`,
-    `,"background_color":`
-  );
+  const hack = atob(encodedTokenUri.slice(dataStartIndex))
+    .replace(`"background_color":`, `,"background_color":`) // Goerli fix
+    .replace(",,", ","); // Rinkeby fix
 
   const tokenUri = JSON.parse(hack)?.image;
   return tokenUri;
+};
+
+const getBreakEvenDays = (
+  alphaAccrualFactor: Decimal,
+  marketPricePremium: Decimal,
+  claimBondFee: Decimal
+): Decimal => {
+  if (marketPricePremium.lte(1)) return Decimal.INFINITY;
+  return alphaAccrualFactor.div(marketPricePremium.mul(Decimal.ONE.sub(claimBondFee)).sub(1));
+};
+
+const getFutureBLusdAccrualFactor = (
+  floorPrice: Decimal,
+  daysInFuture: Decimal,
+  alphaAccrualFactor: Decimal,
+  bondAgeInDays = Decimal.ZERO
+): Decimal => {
+  const duration = daysInFuture.sub(bondAgeInDays);
+  return Decimal.ONE.div(floorPrice).mul(duration.div(duration.add(alphaAccrualFactor)));
+};
+
+const getRebondDays = (
+  alphaAccrualFactor: Decimal,
+  marketPricePremium: Decimal,
+  claimBondFee: Decimal
+): Decimal => {
+  if (marketPricePremium.lte(1)) return Decimal.INFINITY;
+  const sqrt = Decimal.from(
+    Math.sqrt(parseFloat(Decimal.ONE.sub(claimBondFee).mul(marketPricePremium).toString()))
+  );
+  const dividend = Decimal.ONE.add(sqrt);
+  const divisor = Decimal.ONE.sub(claimBondFee).mul(marketPricePremium).gt(1)
+    ? Decimal.ONE.sub(claimBondFee).mul(marketPricePremium).sub(1)
+    : Decimal.ONE;
+  return alphaAccrualFactor.mul(dividend.div(divisor));
+};
+
+const getFutureDateByDays = (days: number): Date => {
+  return new Date(Math.round(Date.now() + daysToMilliseconds(days)));
 };
 
 export {
@@ -46,9 +84,14 @@ export {
   toFloat,
   numberify,
   decimalify,
+  percentify,
   getBondAgeInDays,
   daysToMilliseconds,
   dateWithoutHours,
   getReturn,
-  getTokenUri
+  getTokenUri,
+  getFutureBLusdAccrualFactor,
+  getBreakEvenDays,
+  getRebondDays,
+  getFutureDateByDays
 };

--- a/packages/dev-frontend/src/components/Bonds/utils.ts
+++ b/packages/dev-frontend/src/components/Bonds/utils.ts
@@ -3,8 +3,7 @@ import { BigNumber } from "ethers";
 
 const milliseconds = (seconds: number) => seconds * 1000;
 
-const toFloat = (decimal: Decimal, precision = null): number =>
-  parseFloat(decimal.prettify(precision ?? 2));
+const toFloat = (decimal: Decimal): number => parseFloat(decimal.toString());
 
 const numberify = (bigNumber: BigNumber): number => bigNumber.toNumber();
 
@@ -25,7 +24,21 @@ const getReturn = (accrued: Decimal, deposit: Decimal, marketPrice: Decimal): st
   if (accruedLusdValue.lt(deposit)) {
     return (parseFloat(accruedLusdValue.toString()) - parseFloat(deposit.toString())).toFixed(2);
   }
-  return accruedLusdValue.sub(deposit).prettify(2);
+  return parseFloat(accruedLusdValue.sub(deposit).toString()).toFixed(2);
+};
+
+const getTokenUri = (encodedTokenUri: string): string => {
+  // HACK/TODO: new goerli deployment has fixed data format issue, switch to it
+  const dataStartIndex = encodedTokenUri.indexOf("base64,") + "base64,".length;
+  if (dataStartIndex === -1) return "TODO:"; // TODO: should we render an error image?
+
+  const hack = atob(encodedTokenUri.slice(dataStartIndex)).replace(
+    `"background_color":`,
+    `,"background_color":`
+  );
+
+  const tokenUri = JSON.parse(hack)?.image;
+  return tokenUri;
 };
 
 export {
@@ -36,5 +49,6 @@ export {
   getBondAgeInDays,
   daysToMilliseconds,
   dateWithoutHours,
-  getReturn
+  getReturn,
+  getTokenUri
 };

--- a/packages/dev-frontend/src/components/Bonds/views/actioning/Actioning.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/actioning/Actioning.tsx
@@ -10,6 +10,7 @@ import { Cancel } from "./actions/cancel/Cancel";
 import { Claim } from "./actions/claim/Claim";
 import { Warning } from "../../../Warning";
 import { ReactModal } from "../../../ReactModal";
+import { percentify } from "../../utils";
 
 export const Actioning: React.FC = () => {
   const { dispatchEvent, view, selectedBond: bond } = useBondView();
@@ -110,7 +111,7 @@ export const Actioning: React.FC = () => {
         {view === "CLAIMING" && (
           <Record
             name={l.BOND_RETURN.term}
-            value={bond.claimNowReturn}
+            value={bond.claimNowReturn.toFixed(2)}
             type="LUSD"
             description={l.BOND_RETURN.description}
           />
@@ -121,21 +122,21 @@ export const Actioning: React.FC = () => {
         <Grid gap="20px" columns={3} sx={{ my: 2, justifyItems: "center" }}>
           <Record
             name={l.REBOND_RETURN.term}
-            value={bond.rebondReturn}
+            value={bond.rebondReturn.toFixed(2)}
             type="LUSD"
             description={l.REBOND_RETURN.description}
           />
 
           <Record
             name={l.REBOND_TIME_ROI.term}
-            value={bond.rebondRoi.mul(100).prettify(2) + "%"}
+            value={percentify(bond.rebondRoi) + "%"}
             type=""
             description={l.REBOND_TIME_ROI.description}
           />
 
           <Record
             name={l.OPTIMUM_APY.term}
-            value={bond.rebondRoi.mul(100).mul(12).prettify(2) + "%"}
+            value={percentify(bond.rebondRoi) + "%"}
             type=""
             description={l.OPTIMUM_APY.description}
           />
@@ -143,7 +144,7 @@ export const Actioning: React.FC = () => {
       </details>
 
       <Box mt={3}>
-        {view === "CLAIMING" && parseFloat(bond.claimNowReturn) < 0 && (
+        {view === "CLAIMING" && bond.claimNowReturn < 0 && (
           <Warning>You are claiming a bond which currently has a negative return</Warning>
         )}
         {view === "CLAIMING" && bond.accrued.gte(bond.rebondAccrual) && (

--- a/packages/dev-frontend/src/components/Bonds/views/creating/Details.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/creating/Details.tsx
@@ -8,7 +8,7 @@ import { InfoIcon } from "../../../InfoIcon";
 import { useBondView } from "../../context/BondViewContext";
 import { HorizontalTimeline, Label, SubLabel } from "../../../HorizontalTimeline";
 import { ActionDescription } from "../../../ActionDescription";
-import { nfts } from "../../context/BondViewProvider";
+import { EXAMPLE_NFT } from "../../context/BondViewProvider";
 import * as l from "../../lexicon";
 import { useWizard } from "../../../Wizard/Context";
 import { Warning } from "../../../Warning";
@@ -89,7 +89,7 @@ export const Details: React.FC<DetailsProps> = ({ onBack }) => {
             borderRadius: "14%",
             borderColor: "white"
           }}
-          src={nfts.PENDING}
+          src={EXAMPLE_NFT}
         />
         <InfoIcon
           tooltip={

--- a/packages/dev-frontend/src/components/Bonds/views/idle/Bond.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/idle/Bond.tsx
@@ -78,7 +78,17 @@ export const Bond: React.FC<BondProps> = ({ bond, style }) => {
         ...style
       }}
     >
-      <Flex sx={{ width: 150, height: 210 }}>
+      <Flex
+        sx={{
+          width: 150,
+          height: 210,
+          boxShadow: 2,
+          borderRadius: 10,
+          border: 1,
+          borderColor: "muted",
+          bg: "background"
+        }}
+      >
         <Image
           sx={{ cursor: "pointer", width: "100%", height: "100%" }}
           src={bond.tokenUri}

--- a/packages/dev-frontend/src/components/Bonds/views/idle/Bond.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/idle/Bond.tsx
@@ -1,6 +1,5 @@
 import { Card, Flex, Button, Link, Image, ThemeUIStyleObject } from "theme-ui";
 import { EventType, HorizontalTimeline } from "../../../HorizontalTimeline";
-import { nfts } from "../../context/BondViewProvider";
 import { Record } from "../../Record";
 import { Actions } from "./actions/Actions";
 import type { Bond as BondType } from "../../context/transitions";
@@ -64,7 +63,6 @@ type BondProps = { bond: BondType; style?: ThemeUIStyleObject };
 
 export const Bond: React.FC<BondProps> = ({ bond, style }) => {
   const events = getBondEvents(bond);
-
   return (
     <Flex
       sx={{
@@ -75,56 +73,14 @@ export const Bond: React.FC<BondProps> = ({ bond, style }) => {
       }}
     >
       <Flex>
-        {bond.status === "PENDING" && (
-          <Image
-            sx={{ height: 200, cursor: "pointer", borderRadius: 12 }}
-            src={nfts[bond.status]}
-            alt="TODO"
-            onClick={() => {
-              window.open("https://opensea.io", "_blank");
-            }}
-          />
-        )}
-        {bond.status === "CANCELLED" && (
-          <>
-            <Image sx={{ width: 148, cursor: "pointer", borderRadius: 12 }} src={nfts.PENDING} />
-            <Image
-              sx={{
-                width: 148,
-                cursor: "pointer",
-                borderRadius: "50%",
-                backgroundColor: "transparent",
-                ml: -148,
-                p: "28px"
-              }}
-              src={nfts[bond.status]}
-              alt="TODO"
-              onClick={() => {
-                window.open("https://opensea.io", "_blank");
-              }}
-            />
-          </>
-        )}
-        {bond.status === "CLAIMED" && (
-          <>
-            <Image sx={{ width: 148, cursor: "pointer", borderRadius: 12 }} src={nfts.PENDING} />
-            <Image
-              sx={{
-                width: 148,
-                cursor: "pointer",
-                borderRadius: "50%",
-                backgroundColor: "transparent",
-                ml: -148,
-                p: "28px"
-              }}
-              src={nfts[bond.status]}
-              alt="TODO"
-              onClick={() => {
-                window.open("https://opensea.io", "_blank");
-              }}
-            />
-          </>
-        )}
+        <Image
+          sx={{ width: 150, cursor: "pointer", borderRadius: 12 }}
+          src={bond.tokenUri}
+          alt="TODO"
+          onClick={() => {
+            window.open("https://opensea.io", "_blank");
+          }}
+        />
       </Flex>
       <Card mt={[0, 0, 0, 0]} sx={{ borderRadius: 12, flexGrow: 1 }}>
         <Flex p={[2, 3]} sx={{ flexDirection: "column" }}>

--- a/packages/dev-frontend/src/components/Bonds/views/idle/Bond.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/idle/Bond.tsx
@@ -72,9 +72,9 @@ export const Bond: React.FC<BondProps> = ({ bond, style }) => {
         ...style
       }}
     >
-      <Flex>
+      <Flex sx={{ width: 150, height: 210 }}>
         <Image
-          sx={{ width: 150, cursor: "pointer", borderRadius: 12 }}
+          sx={{ cursor: "pointer", width: "100%", height: "100%" }}
           src={bond.tokenUri}
           alt="TODO"
           onClick={() => {

--- a/packages/dev-frontend/src/components/Bonds/views/idle/Idle.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/idle/Idle.tsx
@@ -8,7 +8,7 @@ import { InfoIcon } from "../../../InfoIcon";
 import { LUSD_OVERRIDE_ADDRESS } from "@liquity/chicken-bonds/lusd/addresses";
 
 export const Idle: React.FC = () => {
-  const { dispatchEvent, bonds, isSynchronizing, getLusdFromFaucet, lusdBalance } = useBondView();
+  const { dispatchEvent, bonds, getLusdFromFaucet, lusdBalance } = useBondView();
 
   const hasBonds = bonds !== undefined && bonds.length > 0;
 
@@ -33,7 +33,7 @@ export const Idle: React.FC = () => {
           <BondList />
         </>
       )}
-      {!hasBonds && !isSynchronizing && (
+      {!hasBonds && (
         <Card>
           <Heading>
             <Flex>
@@ -46,7 +46,7 @@ export const Idle: React.FC = () => {
             </Flex>
           </Heading>
           <Box sx={{ p: [2, 3] }}>
-            {!hasBonds && <Empty />}
+            <Empty />
 
             <Flex variant="layout.actions" mt={4}>
               <Button variant="primary" onClick={() => dispatchEvent("CREATE_BOND_PRESSED")}>

--- a/packages/dev-frontend/src/components/Bonds/views/idle/OptimisticBond.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/idle/OptimisticBond.tsx
@@ -1,6 +1,6 @@
 import { Card, Flex, Button, Link, Image, ThemeUIStyleObject } from "theme-ui";
 import { EventType, HorizontalTimeline, UNKNOWN_DATE } from "../../../HorizontalTimeline";
-import { nfts } from "../../context/BondViewProvider";
+import { EXAMPLE_NFT } from "../../context/BondViewProvider";
 import { Record } from "../../Record";
 import { Actions } from "./actions/Actions";
 import type { OptimisticBond as OptimisticBondType } from "../../context/transitions";
@@ -72,56 +72,14 @@ export const OptimisticBond: React.FC<BondProps> = ({ bond, style }) => {
       }}
     >
       <Flex>
-        {bond.status === "PENDING" && (
-          <Image
-            sx={{ height: 200, cursor: "pointer", borderRadius: 12 }}
-            src={nfts[bond.status]}
-            alt="TODO"
-            onClick={() => {
-              window.open("https://opensea.io", "_blank");
-            }}
-          />
-        )}
-        {bond.status === "CANCELLED" && (
-          <>
-            <Image sx={{ width: 148, cursor: "pointer", borderRadius: 12 }} src={nfts.PENDING} />
-            <Image
-              sx={{
-                width: 148,
-                cursor: "pointer",
-                borderRadius: "50%",
-                backgroundColor: "transparent",
-                ml: -148,
-                p: "28px"
-              }}
-              src={nfts[bond.status]}
-              alt="TODO"
-              onClick={() => {
-                window.open("https://opensea.io", "_blank");
-              }}
-            />
-          </>
-        )}
-        {bond.status === "CLAIMED" && (
-          <>
-            <Image sx={{ width: 148, cursor: "pointer", borderRadius: 12 }} src={nfts.PENDING} />
-            <Image
-              sx={{
-                width: 148,
-                cursor: "pointer",
-                borderRadius: "50%",
-                backgroundColor: "transparent",
-                ml: -148,
-                p: "28px"
-              }}
-              src={nfts[bond.status]}
-              alt="TODO"
-              onClick={() => {
-                window.open("https://opensea.io", "_blank");
-              }}
-            />
-          </>
-        )}
+        <Image
+          sx={{ height: 200, cursor: "pointer", borderRadius: 12 }}
+          src={EXAMPLE_NFT}
+          alt="TODO"
+          onClick={() => {
+            window.open("https://opensea.io", "_blank");
+          }}
+        />
       </Flex>
       <Card mt={[0, 0, 0, 0]} sx={{ borderRadius: 12, flexGrow: 1 }}>
         <Flex p={[2, 3]} sx={{ flexDirection: "column" }}>

--- a/packages/dev-frontend/src/components/Bonds/views/idle/OptimisticBond.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/idle/OptimisticBond.tsx
@@ -1,11 +1,11 @@
-import { Card, Flex, Image, ThemeUIStyleObject } from "theme-ui";
+import { Card, Flex, ThemeUIStyleObject } from "theme-ui";
 import { EventType, HorizontalTimeline, UNKNOWN_DATE } from "../../../HorizontalTimeline";
-import { EXAMPLE_NFT } from "../../context/BondViewProvider";
 import { Record } from "../../Record";
 import { Actions } from "./actions/Actions";
 import type { OptimisticBond as OptimisticBondType } from "../../context/transitions";
 import { Label, SubLabel } from "../../../HorizontalTimeline";
 import * as l from "../../lexicon";
+import { Placeholder } from "../../../Placeholder";
 
 const getBondEvents = (bond: OptimisticBondType): EventType[] => {
   return [
@@ -41,7 +41,8 @@ const getBondEvents = (bond: OptimisticBondType): EventType[] => {
           </Label>
           <SubLabel style={{ fontWeight: 400 }}></SubLabel>
         </>
-      )
+      ),
+      isLoading: true
     },
     {
       date: UNKNOWN_DATE,
@@ -52,7 +53,8 @@ const getBondEvents = (bond: OptimisticBondType): EventType[] => {
           </Label>
           <SubLabel style={{ fontWeight: 400 }}></SubLabel>
         </>
-      )
+      ),
+      isLoading: true
     }
   ];
 };
@@ -71,15 +73,8 @@ export const OptimisticBond: React.FC<BondProps> = ({ bond, style }) => {
         ...style
       }}
     >
-      <Flex>
-        <Image
-          sx={{ height: 200, cursor: "pointer", borderRadius: 12 }}
-          src={EXAMPLE_NFT}
-          alt="TODO"
-          onClick={() => {
-            window.open("https://opensea.io", "_blank");
-          }}
-        />
+      <Flex sx={{ width: 150, height: 210 }}>
+        <Placeholder />
       </Flex>
       <Card mt={[0, 0, 0, 0]} sx={{ borderRadius: 12, flexGrow: 1 }}>
         <Flex p={[2, 3]} sx={{ flexDirection: "column" }}>

--- a/packages/dev-frontend/src/components/Bonds/views/idle/OptimisticBond.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/idle/OptimisticBond.tsx
@@ -1,4 +1,4 @@
-import { Card, Flex, Button, Link, Image, ThemeUIStyleObject } from "theme-ui";
+import { Card, Flex, Image, ThemeUIStyleObject } from "theme-ui";
 import { EventType, HorizontalTimeline, UNKNOWN_DATE } from "../../../HorizontalTimeline";
 import { EXAMPLE_NFT } from "../../context/BondViewProvider";
 import { Record } from "../../Record";
@@ -105,27 +105,14 @@ export const OptimisticBond: React.FC<BondProps> = ({ bond, style }) => {
                 type="LUSD"
                 description={l.BOND_DEPOSIT.description}
               />
-              {bond.status === "PENDING" && (
-                <Record
-                  name={l.MARKET_VALUE.term}
-                  type="LUSD"
-                  description={l.MARKET_VALUE.description}
-                />
-              )}
+
+              <Record
+                name={l.MARKET_VALUE.term}
+                type="LUSD"
+                description={l.MARKET_VALUE.description}
+              />
             </Flex>
-            {bond.status === "PENDING" && <Actions bondId={bond.id} disabled />}
-            {bond.status !== "PENDING" && bond.status === "CLAIMED" && (
-              <Button variant="outline" sx={{ height: "44px" }}>
-                <Link
-                  variant="outline"
-                  href="https://curve.fi"
-                  sx={{ textDecoration: "none" }}
-                  target="external"
-                >
-                  Sell bLUSD
-                </Link>
-              </Button>
-            )}
+            <Actions bondId={bond.id} disabled />
           </Flex>
         </Flex>
       </Card>

--- a/packages/dev-frontend/src/components/Placeholder.tsx
+++ b/packages/dev-frontend/src/components/Placeholder.tsx
@@ -1,4 +1,5 @@
 import { Flex } from "theme-ui";
+import type { ThemeUIStyleObject } from "theme-ui";
 import { keyframes } from "@emotion/react";
 
 const loading = keyframes`
@@ -10,7 +11,9 @@ const loading = keyframes`
   }
 `;
 
-export const Placeholder = () => {
+type PlaceholderProps = { style?: ThemeUIStyleObject };
+
+export const Placeholder: React.FC<PlaceholderProps> = ({ style }) => {
   return (
     <Flex
       sx={{
@@ -19,7 +22,8 @@ export const Placeholder = () => {
         overflow: "hidden",
         borderRadius: "5px",
         height: "100%",
-        width: "56%"
+        width: "100%",
+        ...style
       }}
     >
       <Flex


### PR DESCRIPTION
Use the tokenURI from the bond NFT token.

![image](https://user-images.githubusercontent.com/5167260/188099595-b1afd9d8-1beb-4a88-817d-a44de457e28c.png)

Also:
- Fix rounding issues in bond time estimations.
- Use real NFT images from token data.
- Don't block the app from loading if there are no bonds.
- Don't block app from loading if there are negative values.
- Explicitly handle market price premium being less than 1

Next PR:
- Switch Goerli addresses to the latest: https://github.com/liquity/ChickenBond/blob/main/LUSDChickenBonds/bindings/deployments/goerli.json (fixes the Luchadore NFT image data formatting issue)