### PR TITLE
Fix incorrect accrued bLUSD values at milestones

### DIFF
--- a/packages/dev-frontend/src/components/Bonds/context/api.ts
+++ b/packages/dev-frontend/src/components/Bonds/context/api.ts
@@ -110,7 +110,7 @@ const getAccountBonds = async (
           ? UNKNOWN_DATE
           : getFutureDateByDays(toFloat(breakEvenDays) - bondAgeInDays);
       const rebondTime =
-        breakEvenDays === Decimal.INFINITY
+        rebondDays === Decimal.INFINITY
           ? UNKNOWN_DATE
           : getFutureDateByDays(toFloat(rebondDays) - bondAgeInDays);
       const marketValue = decimalify(bondAccrueds[idx]).mul(marketPrice);
@@ -119,6 +119,7 @@ const getAccountBonds = async (
       const claimNowReturn = accrued.isZero ? 0 : getReturn(accrued, deposit, marketPrice);
       const rebondReturn = accrued.isZero ? 0 : getReturn(rebondAccrual, deposit, marketPrice);
       const rebondRoi = rebondReturn / toFloat(deposit);
+      const rebondApr = rebondRoi * (365 / toFloat(rebondDays));
 
       return [
         ...accumulator,
@@ -137,7 +138,8 @@ const getAccountBonds = async (
           marketValue,
           rebondReturn,
           claimNowReturn,
-          rebondRoi
+          rebondRoi,
+          rebondApr
         }
       ];
     }, [])

--- a/packages/dev-frontend/src/components/Bonds/context/api.ts
+++ b/packages/dev-frontend/src/components/Bonds/context/api.ts
@@ -91,14 +91,19 @@ const getAccountBonds = async (
       const bondAgeInDays = getBondAgeInDays(startTime);
       const rebondDays = getRebondDays(alphaAccrualFactor, marketPricePremium, claimBondFee);
       const breakEvenDays = getBreakEvenDays(alphaAccrualFactor, marketPricePremium, claimBondFee);
+      const depositMinusClaimBondFee = Decimal.ONE.sub(claimBondFee).mul(deposit);
       const rebondAccrual =
         rebondDays === Decimal.INFINITY
           ? Decimal.INFINITY
-          : getFutureBLusdAccrualFactor(floorPrice, rebondDays, alphaAccrualFactor).mul(deposit);
+          : getFutureBLusdAccrualFactor(floorPrice, rebondDays, alphaAccrualFactor).mul(
+              depositMinusClaimBondFee
+            );
       const breakEvenAccrual =
         breakEvenDays === Decimal.INFINITY
           ? Decimal.INFINITY
-          : getFutureBLusdAccrualFactor(floorPrice, breakEvenDays, alphaAccrualFactor).mul(deposit);
+          : getFutureBLusdAccrualFactor(floorPrice, breakEvenDays, alphaAccrualFactor).mul(
+              depositMinusClaimBondFee
+            );
 
       const breakEvenTime =
         breakEvenDays === Decimal.INFINITY

--- a/packages/dev-frontend/src/components/Bonds/context/transitions.ts
+++ b/packages/dev-frontend/src/components/Bonds/context/transitions.ts
@@ -181,6 +181,7 @@ export type Bond = {
   marketValue: Decimal;
   rebondReturn: number;
   rebondRoi: number;
+  rebondApr: number;
   claimNowReturn: number;
 };
 

--- a/packages/dev-frontend/src/components/Bonds/views/actioning/Actioning.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/actioning/Actioning.tsx
@@ -129,14 +129,14 @@ export const Actioning: React.FC = () => {
 
           <Record
             name={l.REBOND_TIME_ROI.term}
-            value={percentify(bond.rebondRoi) + "%"}
+            value={percentify(bond.rebondRoi).toFixed(2) + "%"}
             type=""
             description={l.REBOND_TIME_ROI.description}
           />
 
           <Record
             name={l.OPTIMUM_APY.term}
-            value={percentify(bond.rebondRoi) + "%"}
+            value={percentify(bond.rebondRoi).toFixed(2) + "%"}
             type=""
             description={l.OPTIMUM_APY.description}
           />

--- a/packages/dev-frontend/src/components/Bonds/views/actioning/Actioning.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/actioning/Actioning.tsx
@@ -136,7 +136,7 @@ export const Actioning: React.FC = () => {
 
           <Record
             name={l.OPTIMUM_APY.term}
-            value={percentify(bond.rebondRoi).toFixed(2) + "%"}
+            value={percentify(bond.rebondApr).toFixed(2) + "%"}
             type=""
             description={l.OPTIMUM_APY.description}
           />

--- a/packages/dev-frontend/src/components/Bonds/views/creating/Details.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/creating/Details.tsx
@@ -58,8 +58,9 @@ export const Details: React.FC<DetailsProps> = ({ onBack }) => {
   if (protocolInfo === undefined || simulatedProtocolInfo === undefined || lusdBalance === undefined)
     return null;
 
+  const depositMinusClaimBondFee = Decimal.ONE.sub(protocolInfo.claimBondFee).mul(deposit);
   const rebondReturn = getReturn(
-    deposit.mul(simulatedProtocolInfo.rebondAccrualFactor),
+    depositMinusClaimBondFee.mul(simulatedProtocolInfo.rebondAccrualFactor),
     deposit,
     simulatedProtocolInfo.simulatedMarketPrice
   );
@@ -128,7 +129,7 @@ export const Details: React.FC<DetailsProps> = ({ onBack }) => {
               label: (
                 <>
                   <Label description={l.BREAK_EVEN_TIME.description}>{l.BREAK_EVEN_TIME.term}</Label>
-                  <SubLabel>{`${deposit
+                  <SubLabel>{`${depositMinusClaimBondFee
                     .mul(simulatedProtocolInfo.breakEvenAccrualFactor)
                     .prettify(2)} bLUSD`}</SubLabel>
                 </>
@@ -141,7 +142,7 @@ export const Details: React.FC<DetailsProps> = ({ onBack }) => {
                   <Label description={l.OPTIMUM_REBOND_TIME.description}>
                     {l.OPTIMUM_REBOND_TIME.term}
                   </Label>
-                  <SubLabel>{`${deposit
+                  <SubLabel>{`${depositMinusClaimBondFee
                     .mul(simulatedProtocolInfo.rebondAccrualFactor)
                     .prettify(2)} bLUSD`}</SubLabel>
                 </>


### PR DESCRIPTION
Chicken-in fee wasn't taken into account. Also truncate percentages with a large number of decimals, as suggested by @cvalkan.