### PR TITLE
fix: get the most up-to-date alpha

### DIFF
--- a/packages/dev-frontend/src/components/Bonds/context/api.ts
+++ b/packages/dev-frontend/src/components/Bonds/context/api.ts
@@ -195,7 +195,7 @@ const getProtocolInfo = async (
   const fairPrice = marketPrice.mul(1.1); /* TODO: use real formula */
   const floorPrice = bLusdSupply.isZero ? Decimal.ONE : reserveSize.div(bLusdSupply);
   const claimBondFee = decimalify(await chickenBondManager.CHICKEN_IN_AMM_FEE());
-  const alphaAccrualFactor = decimalify(await chickenBondManager.accrualParameter()).div(
+  const alphaAccrualFactor = decimalify(await chickenBondManager.calcUpdatedAccrualParameter()).div(
     24 * 60 * 60
   );
   const {


### PR DESCRIPTION
`accrualParameter` is only updated in storage when there's user interaction, however all the read functions (like `calcAccruedBLUSD()`) internally calculate what alpha would be after an update, and use that in calculations. It makes sense for us to also base UI calculations on the predicted value.