### PR TITLE
doc: fix broken link, description and typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ In the first year after launch:
 
 - The Liquity admin address may transfer tokens **only to verified lockup contracts with an unlock date at least one year after system deployment**
 
-Also, separate LQTY allocations are made at deployent to an EOA that will hold an amount of LQTY for bug bounties/hackathons and to a Uniswap LP reward contract. Aside from these allocations, the only LQTY made freely available in this first year is the LQTY that is publically issued to Stability Providers via the `CommunityIssuance` contract.
+Also, separate LQTY allocations are made at deployment to an EOA that will hold an amount of LQTY for bug bounties/hackathons and to a Uniswap LP reward contract. Aside from these allocations, the only LQTY made freely available in this first year is the LQTY that is publically issued to Stability Providers via the `CommunityIssuance` contract.
 
 ### Lockup Implementation and admin transfer restriction
 
@@ -484,7 +484,7 @@ Thus, nodes need only be re-inserted to the sorted list upon a Trove operation -
 
 ![Flow of Ether](images/ETH_flows.svg)
 
-Ether in the system lives in three Pools: the ActivePool, the DefaultPool and the StabilityPool. When an operation is made, Ether is transferred in one of three ways:
+Ether in the system lives in four Pools: the ActivePool, the DefaultPool, the StabilityPool and the CollSurplusPool. When an operation is made, Ether is transferred in one of three ways:
 
 - From a user to a Pool
 - From a Pool to a user

--- a/packages/contracts/contracts/StabilityPool.sol
+++ b/packages/contracts/contracts/StabilityPool.sol
@@ -45,7 +45,7 @@ import "./Dependencies/console.sol";
  * Stability Pool, they get a snapshot of the latest P and S: P_t and S_t, respectively.
  *
  * The formula for a depositor's accumulated ETH gain is derived here:
- * https://github.com/liquity/dev/blob/main/packages/contracts/mathProofs/Scalable%20Compounding%20Stability%20Pool%20Deposits.pdf
+ * https://github.com/liquity/dev/blob/83b36b8a48ebb3c9f454f4d40dcbac85fd68b434/packages/contracts/mathProofs/Scalable%20Compounding%20Stability%20Pool%20Deposits.pdf
  *
  * For a given deposit d_t, the ratio P/P_t tells us the factor by which a deposit has decreased since it joined the Stability Pool,
  * and the term d_t * (S - S_t)/P_t gives us the deposit's total accumulated ETH gain.


### PR DESCRIPTION
The link, https://github.com/liquity/dev/blob/main/packages/contracts/mathProofs/Scalable%20Compounding%20Stability%20Pool%20Deposits.pdf, used in the comment of the StabilityPool.sol is broken. Thus, replace it with the valid link: https://github.com/liquity/dev/blob/83b36b8a48ebb3c9f454f4d40dcbac85fd68b434/packages/contracts/mathProofs/Scalable%20Compounding%20Stability%20Pool%20Deposits.pdf

There is a mistake on description and a typo in the README.md.
One is that Ether in the system lives in four Pools instead of three pool.
Another is that "deployent" is a typo.