### PR TITLE
Add bLUSD APR and Yield amplification stat

### DIFF
--- a/packages/dev-frontend/src/components/BondStats.tsx
+++ b/packages/dev-frontend/src/components/BondStats.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Card, Heading, Text, Flex } from "theme-ui";
+import { Decimal } from "@liquity/lib-base";
 import * as l from "../components/Bonds/lexicon";
 import { Statistic } from "./Statistic";
 import { TreasuryChart } from "./TreasuryChart";
@@ -41,20 +42,38 @@ export const BondStats: React.FC<BondStatsProps> = () => {
       </Statistic>
       <Statistic name={l.BLUSD_FAIR_PRICE.term} tooltip={l.BLUSD_FAIR_PRICE.description}>
         <Metric
-          value={`${protocolInfo.fairPrice.lower.prettify(
-            2
-          )} - ${protocolInfo.fairPrice.upper.prettify(2)}`}
+          value={
+            protocolInfo.fairPrice.lower.eq(Decimal.INFINITY)
+              ? "N/A"
+              : `${protocolInfo.fairPrice.lower.prettify(
+                  2
+                )} - ${protocolInfo.fairPrice.upper.prettify(2)}`
+          }
           unit="LUSD"
         />
       </Statistic>
       <Statistic name={l.BLUSD_FLOOR_PRICE.term} tooltip={l.BLUSD_FLOOR_PRICE.description}>
         <Metric value={protocolInfo.floorPrice.prettify(2)} unit="LUSD" />
       </Statistic>
+      <Statistic name={l.BLUSD_APR.term} tooltip={l.BLUSD_APR.description}>
+        <Metric
+          value={protocolInfo.bLusdApr ? protocolInfo.bLusdApr.mul(100).prettify(2) : "N/A"}
+          unit="%"
+        />
+      </Statistic>
+      <Statistic
+        name={l.BLUSD_YIELD_AMPLIFICATION.term}
+        tooltip={l.BLUSD_YIELD_AMPLIFICATION.description}
+      >
+        <Metric
+          value={
+            protocolInfo.yieldAmplification ? protocolInfo.yieldAmplification.prettify(2) : "N/A"
+          }
+          unit="x"
+        />
+      </Statistic>
       <Statistic name={l.BLUSD_SUPPLY.term} tooltip={l.BLUSD_SUPPLY.description}>
         <Metric value={protocolInfo.bLusdSupply.shorten()} unit="bLUSD" />
-      </Statistic>
-      <Statistic name={"Yield amplification"} tooltip={"TODO"}>
-        <Metric value={"1.1"} unit="x" />
       </Statistic>
 
       <Heading as="h2" sx={{ mt: 3, fontWeight: "body" }}>

--- a/packages/dev-frontend/src/components/Bonds/context/api.ts
+++ b/packages/dev-frontend/src/components/Bonds/context/api.ts
@@ -268,7 +268,7 @@ const getProtocolInfo = async (
       treasury.pending.add(treasury.reserve)
     );
     const permanentYield = cachedYearnApys.lusd3Crv.mul(treasury.permanent);
-    const overallApr = pendingAndReserveYield.add(permanentYield).div(bLusdSupply);
+    const overallApr = pendingAndReserveYield.add(permanentYield).div(treasury.reserve);
     yieldAmplification = overallApr.div(cachedYearnApys.stabilityPool);
     bLusdApr = overallApr;
   }

--- a/packages/dev-frontend/src/components/Bonds/context/api.ts
+++ b/packages/dev-frontend/src/components/Bonds/context/api.ts
@@ -45,6 +45,48 @@ type Maybe<T> = T | undefined;
 
 const BOND_STATUS: BondStatus[] = ["NON_EXISTENT", "PENDING", "CANCELLED", "CLAIMED"];
 
+const LUSD_3CRV_POOL_ADDRESS = "0xEd279fDD11cA84bEef15AF5D39BB4d4bEE23F0cA";
+const LUSD_TOKEN_ADDRESS = "0x5f98805A4E8be255a32880FDeC7F6728C6568bA0";
+
+type CachedYearnApys = {
+  lusd3Crv: Decimal | undefined;
+  stabilityPool: Decimal | undefined;
+};
+let cachedYearnApys: CachedYearnApys = {
+  lusd3Crv: undefined,
+  stabilityPool: undefined
+};
+
+type YearnVault = Partial<{
+  token: {
+    address: string;
+  };
+  apy: {
+    net_apy: number;
+  };
+}>;
+
+const cacheYearnVaultApys = async (): Promise<void> => {
+  if (cachedYearnApys.lusd3Crv !== undefined) return;
+
+  const yearnResponse = (await (
+    await window.fetch("https://api.yearn.finance/v1/chains/1/vaults/all")
+  ).json()) as YearnVault[];
+
+  const lusd3CrvVault = yearnResponse.find(
+    vault => vault?.token?.address === LUSD_3CRV_POOL_ADDRESS
+  );
+
+  const stabilityPoolVault = yearnResponse.find(
+    vault => vault?.token?.address === LUSD_TOKEN_ADDRESS
+  );
+
+  if (lusd3CrvVault?.apy?.net_apy === undefined || stabilityPoolVault?.apy?.net_apy === undefined)
+    return;
+  cachedYearnApys.lusd3Crv = Decimal.from(lusd3CrvVault.apy.net_apy);
+  cachedYearnApys.stabilityPool = Decimal.from(stabilityPoolVault.apy.net_apy);
+};
+
 const getAccountBonds = async (
   account: string,
   bondNft: BondNFT,
@@ -210,6 +252,27 @@ const getProtocolInfo = async (
     total: decimalify(pending.add(reserve).add(permanent))
   };
 
+  if (cachedYearnApys.lusd3Crv === undefined || cachedYearnApys.stabilityPool === undefined) {
+    await cacheYearnVaultApys();
+  }
+
+  let yieldAmplification: Maybe<Decimal> = undefined;
+  let bLusdApr: Maybe<Decimal> = undefined;
+
+  if (
+    cachedYearnApys.lusd3Crv !== undefined &&
+    cachedYearnApys.stabilityPool !== undefined &&
+    bLusdSupply.gt(0)
+  ) {
+    const pendingAndReserveYield = cachedYearnApys.stabilityPool.mul(
+      treasury.pending.add(treasury.reserve)
+    );
+    const permanentYield = cachedYearnApys.lusd3Crv.mul(treasury.permanent);
+    const overallApr = pendingAndReserveYield.add(permanentYield).div(bLusdSupply);
+    yieldAmplification = overallApr.div(cachedYearnApys.stabilityPool);
+    bLusdApr = overallApr;
+  }
+
   const fairPrice = {
     lower: treasury.total.sub(treasury.pending).div(bLusdSupply),
     upper: treasury.total.div(bLusdSupply)
@@ -250,7 +313,9 @@ const getProtocolInfo = async (
     rebondAccrualFactor,
     breakEvenDays,
     rebondDays,
-    simulatedMarketPrice
+    simulatedMarketPrice,
+    yieldAmplification,
+    bLusdApr
   };
 };
 

--- a/packages/dev-frontend/src/components/Bonds/context/transitions.ts
+++ b/packages/dev-frontend/src/components/Bonds/context/transitions.ts
@@ -217,6 +217,8 @@ export type ProtocolInfo = {
   rebondAccrualFactor: Decimal;
   breakEvenDays?: Decimal;
   rebondDays?: Decimal;
+  yieldAmplification?: Decimal;
+  bLusdApr?: Decimal;
 };
 
 export type TransactionStatus = "IDLE" | "PENDING" | "CONFIRMED" | "FAILED";

--- a/packages/dev-frontend/src/components/Bonds/lexicon.ts
+++ b/packages/dev-frontend/src/components/Bonds/lexicon.ts
@@ -174,6 +174,16 @@ export const BLUSD_FLOOR_PRICE = {
     "The amount of LUSD that an arbitrageur could redeem bLUSD for thus creating a lower bound bLUSD market price."
 };
 
+export const BLUSD_APR = {
+  term: "APR",
+  description: "The APR of bLUSD, based on the yield generated from each bucket in the Treasury."
+};
+
+export const BLUSD_YIELD_AMPLIFICATION = {
+  term: "Yield amplification",
+  description: "The bLUSD token generates a yield which is a multiple of the Stability Pool yield."
+};
+
 export const TREASURY_TOTAL = {
   term: "Total",
   description:


### PR DESCRIPTION
Use Yearn to get yield rates of LUSD-3CRV and Stability Pool strategies, then use these rates to calculate bLUSD's APR and Yield amplification.

Example usage on our Goerli testnet game:
<img width="364" alt="image" src="https://user-images.githubusercontent.com/5167260/192336082-a1c1dd0b-1bbc-4919-a220-3dece98f098d.png">
