### PR TITLE
feat: configurable slippage tolerance

### DIFF
--- a/packages/dev-frontend/src/components/Bonds/views/managing/PoolDetails.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/managing/PoolDetails.tsx
@@ -1,7 +1,6 @@
-/** @jsxImportSource theme-ui */
 import { Decimal } from "@liquity/lib-base";
-import { Flex, Text, Box } from "theme-ui";
-import { StaticRow } from "../../../Trove/Editor";
+import { Text, Box } from "theme-ui";
+import { StaticRow, StaticAmounts } from "../../../Trove/Editor";
 import { useBondView } from "../../context/BondViewContext";
 
 const PoolBalance: React.FC<{ symbol: string }> = ({ symbol, children }) => (
@@ -17,11 +16,16 @@ export const PoolDetails: React.FC = () => {
 
   return (
     <details>
-      <summary sx={{ cursor: "pointer", mb: 3 }}>Pool details</summary>
+      <Box as="summary" sx={{ cursor: "pointer", mb: 3 }}>
+        Pool details
+      </Box>
 
       <Box sx={{ mt: 3 }}>
-        <StaticRow label="Pool balance" inputId="deposit-pool-balance">
-          <Flex sx={{ alignItems: "center" }}>
+        <StaticRow label="Pool balance">
+          <StaticAmounts
+            sx={{ alignItems: "center", justifyContent: "flex-start" }}
+            inputId="deposit-pool-balance"
+          >
             <PoolBalance symbol="bLUSD">
               {(bLusdAmmBLusdBalance ?? Decimal.ZERO).prettify(2)}
             </PoolBalance>
@@ -31,7 +35,7 @@ export const PoolDetails: React.FC = () => {
             <PoolBalance symbol="LUSD">
               {(bLusdAmmLusdBalance ?? Decimal.ZERO).prettify(2)}
             </PoolBalance>
-          </Flex>
+          </StaticAmounts>
         </StaticRow>
 
         <StaticRow

--- a/packages/dev-frontend/src/components/Bonds/views/managing/WithdrawPane.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/managing/WithdrawPane.tsx
@@ -4,7 +4,7 @@ import { Flex, Button, Spinner, Label, Radio, Text } from "theme-ui";
 import { Amount } from "../../../ActionDescription";
 import { ErrorDescription } from "../../../ErrorDescription";
 import { Icon } from "../../../Icon";
-import { DisabledEditableRow, EditableRow } from "../../../Trove/Editor";
+import { DisabledEditableAmounts, DisabledEditableRow, EditableRow } from "../../../Trove/Editor";
 import { useBondView } from "../../context/BondViewContext";
 import { BLusdAmmTokenIndex } from "../../context/transitions";
 import { PoolDetails } from "./PoolDetails";
@@ -144,7 +144,7 @@ export const WithdrawPane: React.FC = () => {
       </Flex>
 
       <DisabledEditableRow label="Withdraw" inputId="withdraw-output-amount">
-        <Flex sx={{ alignItems: "center" }}>
+        <DisabledEditableAmounts sx={{ justifyContent: "flex-start" }}>
           {Array.from(withdrawal.entries()).map(([token, amount], i) => (
             <>
               {i > 0 && <Text sx={{ fontWeight: "light", mx: "12px" }}>+</Text>}
@@ -153,7 +153,7 @@ export const WithdrawPane: React.FC = () => {
               </WithdrawnAmount>
             </>
           ))}
-        </Flex>
+        </DisabledEditableAmounts>
       </DisabledEditableRow>
 
       <PoolDetails />

--- a/packages/dev-frontend/src/components/Bonds/views/swapping/SwapPane.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/swapping/SwapPane.tsx
@@ -1,10 +1,19 @@
+/** @jsxImportSource theme-ui */
+
 import { Decimal, Percent } from "@liquity/lib-base";
-import React, { useEffect, useState } from "react";
-import { Flex, Button, Spinner, Heading, Close } from "theme-ui";
+import React, { useEffect, useRef, useState } from "react";
+import { Flex, Button, Spinner, Heading, Close, Box, Label, Radio, Input } from "theme-ui";
 import { Amount } from "../../../ActionDescription";
 import { ErrorDescription } from "../../../ErrorDescription";
 import { Icon } from "../../../Icon";
-import { DisabledEditableRow, EditableRow, StaticRow } from "../../../Trove/Editor";
+import { Placeholder } from "../../../Placeholder";
+import {
+  DisabledEditableAmounts,
+  DisabledEditableRow,
+  EditableRow,
+  StaticAmounts,
+  StaticRow
+} from "../../../Trove/Editor";
 import { useBondView } from "../../context/BondViewContext";
 import { BLusdAmmTokenIndex } from "../../context/transitions";
 
@@ -20,6 +29,16 @@ const outputToken: Record<BLusdAmmTokenIndex, BLusdAmmTokenIndex> = {
 
 const marginalAmount = Decimal.ONE.div(1000);
 
+type SlippageTolerance = "half" | "one" | "custom";
+
+const checkSlippageTolerance = (value: string): SlippageTolerance => {
+  if (value === "half" || value === "one" || value === "custom") {
+    return value;
+  }
+
+  throw new Error(`invalid slippage tolerance choice "${value}"`);
+};
+
 export const SwapPane: React.FC = () => {
   const {
     dispatchEvent,
@@ -28,20 +47,35 @@ export const SwapPane: React.FC = () => {
     lusdBalance,
     bLusdBalance,
     isInputTokenApprovedWithBLusdAmm,
+    bLusdAmmBLusdBalance,
+    bLusdAmmLusdBalance,
     getExpectedSwapOutput
   } = useBondView();
   const editingState = useState<string>();
   const inputTokenBalance =
     (inputToken === BLusdAmmTokenIndex.BLUSD ? bLusdBalance : lusdBalance) ?? Decimal.ZERO;
   const [inputAmount, setInputAmount] = useState<Decimal>(Decimal.ZERO);
-  const [outputAmount, setOutputAmount] = useState<Decimal>(Decimal.ZERO);
-  const [exchangeRate, setExchangeRate] = useState<Decimal>(Decimal.ZERO);
-  const [priceImpact, setPriceImpact] = useState<Decimal>(Decimal.ZERO);
-  const priceImpactPct = new Percent(priceImpact);
+  const [outputAmount, setOutputAmount] = useState<Decimal>();
+  const [exchangeRate, setExchangeRate] = useState<Decimal>();
+  const [priceImpact, setPriceImpact] = useState<Decimal>();
+  const [slippageToleranceChoice, setSlippageToleranceChoice] = useState<SlippageTolerance>("half");
+  const [customSlippageTolerance, setCustomSlippageTolerance] = useState<Decimal>();
+  const [customSlippageToleranceFocus, setCustomSlippageToleranceFocus] = useState(false);
+  const customSlippageToleranceRef = useRef<HTMLInputElement>(null);
 
+  const priceImpactPct = priceImpact && new Percent(priceImpact);
   const isApprovePending = statuses.APPROVE_AMM === "PENDING";
   const isSwapPending = statuses.SWAP === "PENDING";
   const isBalanceInsufficient = inputAmount.gt(inputTokenBalance);
+  const isSlippageToleranceInvalid =
+    slippageToleranceChoice === "custom" &&
+    (!customSlippageTolerance ||
+      customSlippageTolerance.lt(0.001) ||
+      customSlippageTolerance.gt(Decimal.ONE));
+  const isSlippageToleranceHigh = customSlippageTolerance?.gt(0.05);
+
+  // Used in dependency list of effect to recalculate output amount in case of pool changes
+  const poolState = `${bLusdAmmBLusdBalance},${bLusdAmmLusdBalance}`;
 
   const handleDismiss = () => {
     dispatchEvent("ABORT_PRESSED");
@@ -52,9 +86,26 @@ export const SwapPane: React.FC = () => {
   };
 
   const handleConfirmPressed = () => {
+    if (!outputAmount) {
+      return;
+    }
+
+    const slippageTolerance =
+      slippageToleranceChoice === "half"
+        ? Decimal.from(0.005)
+        : slippageToleranceChoice === "one"
+        ? Decimal.from(0.01)
+        : customSlippageTolerance;
+
+    if (!slippageTolerance || isSlippageToleranceInvalid) {
+      return;
+    }
+
+    const minOutputFactor = Decimal.ONE.sub(slippageTolerance);
+
     dispatchEvent("CONFIRM_PRESSED", {
       inputAmount,
-      minOutputAmount: outputAmount.mul(0.995) // 0.5% slippage tolerance
+      minOutputAmount: outputAmount.mul(minOutputFactor)
     });
   };
 
@@ -62,10 +113,17 @@ export const SwapPane: React.FC = () => {
     dispatchEvent("BACK_PRESSED");
   };
 
+  const handleSlippageToleranceChange = (e: React.ChangeEvent<HTMLInputElement>) =>
+    setSlippageToleranceChoice(checkSlippageTolerance(e.target.value));
+
   useEffect(() => {
     let cancelled = false;
 
     const timeoutId = setTimeout(async () => {
+      setOutputAmount(undefined);
+      setExchangeRate(undefined);
+      setPriceImpact(undefined);
+
       try {
         const [marginalOutput, outputAmount] = await Promise.all([
           getExpectedSwapOutput(inputToken, marginalAmount),
@@ -93,7 +151,7 @@ export const SwapPane: React.FC = () => {
       clearTimeout(timeoutId);
       cancelled = true;
     };
-  }, [inputToken, inputAmount, getExpectedSwapOutput]);
+  }, [inputToken, inputAmount, getExpectedSwapOutput, poolState]);
 
   return (
     <>
@@ -127,26 +185,127 @@ export const SwapPane: React.FC = () => {
         <Icon name="arrow-down" size="lg" />
       </Flex>
 
-      <DisabledEditableRow
-        label="Buy"
-        inputId="swap-output-amount"
-        amount={outputAmount.prettify(2)}
-        unit={tokenSymbol[outputToken[inputToken]]}
-      />
+      <DisabledEditableRow label="Buy">
+        {outputAmount ? (
+          <DisabledEditableAmounts
+            inputId="swap-output-amount"
+            amount={outputAmount.prettify(2)}
+            unit={tokenSymbol[outputToken[inputToken]]}
+          />
+        ) : (
+          <DisabledEditableAmounts inputId="swap-output-amount">
+            <Box sx={{ width: "160px", height: "20px", mt: "10px", mb: "6px" }}>
+              <Placeholder />
+            </Box>
+          </DisabledEditableAmounts>
+        )}
+      </DisabledEditableRow>
 
-      <StaticRow
-        label="Exchange rate"
-        inputId="swap-exchange-rate"
-        amount={exchangeRate.prettify(4)}
-        unit={`${tokenSymbol[inputToken]}:${tokenSymbol[outputToken[inputToken]]}`}
-      />
+      <StaticRow label="Exchange rate">
+        {exchangeRate ? (
+          <StaticAmounts
+            inputId="swap-exchange-rate"
+            amount={exchangeRate.prettify(4)}
+            unit={`${tokenSymbol[inputToken]}:${tokenSymbol[outputToken[inputToken]]}`}
+          />
+        ) : (
+          <StaticAmounts inputId="swap-exchange-rate">
+            <Box sx={{ width: "180px", height: "16px", mt: "9px", mb: "5px" }}>
+              <Placeholder />
+            </Box>
+          </StaticAmounts>
+        )}
+      </StaticRow>
 
-      <StaticRow
-        label="Price impact"
-        inputId="swap-price-impact"
-        amount={priceImpactPct.toString(4)}
-        color={priceImpact.gte(0.005) ? "danger" : undefined}
-      />
+      <StaticRow label="Price impact">
+        {priceImpact && priceImpactPct ? (
+          <StaticAmounts
+            inputId="swap-price-impact"
+            amount={priceImpactPct.toString(4)}
+            color={priceImpact.gte(0.005) ? "danger" : undefined}
+          />
+        ) : (
+          <StaticAmounts inputId="swap-price-impact">
+            <Box sx={{ width: "80px", height: "16px", mt: "9px", mb: "5px" }}>
+              <Placeholder />
+            </Box>
+          </StaticAmounts>
+        )}
+      </StaticRow>
+
+      <details>
+        <summary sx={{ cursor: "pointer", mx: 2, mb: 2 }}>Slippage tolerance</summary>
+
+        <Flex sx={{ alignItems: "center", mx: 4, mb: 3 }}>
+          <Label variant="radioLabel">
+            <Radio
+              name="swap-slippage-tolerance"
+              value="half"
+              checked={slippageToleranceChoice === "half"}
+              onChange={handleSlippageToleranceChange}
+            />
+            0.5%
+          </Label>
+
+          <Label variant="radioLabel">
+            <Radio
+              name="swap-slippage-tolerance"
+              value="one"
+              checked={slippageToleranceChoice === "one"}
+              onChange={handleSlippageToleranceChange}
+            />
+            1%
+          </Label>
+
+          <Label variant="radioLabel" sx={{ alignItems: "center" }}>
+            <Radio
+              name="swap-slippage-tolerance"
+              value="custom"
+              checked={slippageToleranceChoice === "custom"}
+              onChange={handleSlippageToleranceChange}
+            />
+            <Input
+              ref={customSlippageToleranceRef}
+              sx={{
+                py: "6px",
+                px: "10px",
+                width: "110px",
+                fontSize: 2,
+                ...(!customSlippageToleranceFocus
+                  ? isSlippageToleranceInvalid
+                    ? { bg: "invalid", borderColor: "danger" }
+                    : isSlippageToleranceHigh
+                    ? { borderColor: "warning" }
+                    : {}
+                  : {})
+              }}
+              type="number"
+              min={0}
+              max={100}
+              step={0.1}
+              placeholder="Custom"
+              onFocus={() => {
+                setSlippageToleranceChoice("custom");
+                setCustomSlippageToleranceFocus(true);
+              }}
+              onKeyDown={e => {
+                if (e.key === "Enter") {
+                  customSlippageToleranceRef.current?.blur();
+                }
+              }}
+              onBlur={() => setCustomSlippageToleranceFocus(false)}
+              onChange={e => {
+                try {
+                  setCustomSlippageTolerance(Decimal.from(e.target.value).div(100));
+                } catch {
+                  setCustomSlippageTolerance(undefined);
+                }
+              }}
+            />
+            &nbsp;%
+          </Label>
+        </Flex>
+      </details>
 
       {isBalanceInsufficient && (
         <ErrorDescription>
@@ -170,7 +329,13 @@ export const SwapPane: React.FC = () => {
           <Button
             variant="primary"
             onClick={handleConfirmPressed}
-            disabled={inputAmount.isZero || isBalanceInsufficient || isSwapPending}
+            disabled={
+              inputAmount.isZero ||
+              !outputAmount ||
+              isBalanceInsufficient ||
+              isSlippageToleranceInvalid ||
+              isSwapPending
+            }
           >
             {isSwapPending ? <Spinner size="28px" sx={{ color: "white" }} /> : <>Confirm</>}
           </Button>

--- a/packages/dev-frontend/src/components/Trove/Editor.tsx
+++ b/packages/dev-frontend/src/components/Trove/Editor.tsx
@@ -64,7 +64,7 @@ const PendingAmount: React.FC<PendingAmountProps & SxProp> = ({ sx, value }) => 
 );
 
 type StaticAmountsProps = {
-  inputId: string;
+  inputId?: string;
   labelledBy?: string;
   amount?: string;
   unit?: string;
@@ -167,10 +167,24 @@ export const StaticRow: React.FC<StaticRowProps> = ({
   labelId,
   labelFor,
   infoIcon,
+  amount,
+  children,
   ...props
 }) => (
-  <Row {...{ label, labelId, labelFor, infoIcon }} sx={{ mt: [-2, -3], pb: [2, 3] }}>
-    <StaticAmounts {...props} />
+  <Row
+    label={label}
+    labelId={labelId}
+    labelFor={labelFor}
+    infoIcon={infoIcon}
+    sx={{ mt: [-2, -3], pb: [2, 3] }}
+  >
+    {amount ? (
+      <StaticAmounts amount={amount} {...props}>
+        {children}
+      </StaticAmounts>
+    ) : (
+      children
+    )}
   </Row>
 );
 
@@ -178,24 +192,37 @@ type DisabledEditableRowProps = Omit<StaticAmountsProps, "labelledBy" | "onClick
   label: string;
 };
 
+export const DisabledEditableAmounts: React.FC<StaticAmountsProps & SxProp> = ({
+  inputId,
+  children,
+  sx,
+  ...props
+}) => (
+  <StaticAmounts
+    sx={{ ...editableStyle, boxShadow: 0, ...sx }}
+    labelledBy={`${inputId}-label`}
+    inputId={inputId}
+    {...props}
+  >
+    {children}
+  </StaticAmounts>
+);
+
 export const DisabledEditableRow: React.FC<DisabledEditableRowProps> = ({
   inputId,
   label,
-  unit,
   amount,
-  color,
-  pendingAmount,
-  pendingColor,
-  children
+  children,
+  ...props
 }) => (
   <Row labelId={`${inputId}-label`} label={label}>
-    <StaticAmounts
-      sx={{ ...editableStyle, boxShadow: 0 }}
-      labelledBy={`${inputId}-label`}
-      {...{ inputId, amount, unit, color, pendingAmount, pendingColor }}
-    >
-      {children}
-    </StaticAmounts>
+    {amount ? (
+      <DisabledEditableAmounts inputId={inputId} amount={amount} {...props}>
+        {children}
+      </DisabledEditableAmounts>
+    ) : (
+      children
+    )}
   </Row>
 );
 

--- a/packages/dev-frontend/src/theme.ts
+++ b/packages/dev-frontend/src/theme.ts
@@ -319,7 +319,7 @@ const theme: Theme = {
     },
 
     radioLabel: {
-      mr: 3,
+      mr: 4,
       width: "unset",
 
       svg: {


### PR DESCRIPTION
Also add placeholders while swap output estimates are loading.

Looks like this:
<img width="613" alt="image" src="https://user-images.githubusercontent.com/60874270/192740684-bdbffb5f-e756-4078-8b7e-737c7be4820b.png">
