### PR TITLE
UI: Various changes picked up on mainnet deployment

### DIFF
--- a/packages/dev-frontend/src/components/BondStats.tsx
+++ b/packages/dev-frontend/src/components/BondStats.tsx
@@ -57,7 +57,11 @@ export const BondStats: React.FC<BondStatsProps> = () => {
       </Statistic>
       <Statistic name={l.BLUSD_APR.term} tooltip={l.BLUSD_APR.description}>
         <Metric
-          value={protocolInfo.bLusdApr ? protocolInfo.bLusdApr.mul(100).prettify(2) : "N/A"}
+          value={
+            protocolInfo.bLusdApr && protocolInfo.bLusdSupply.gt(0)
+              ? protocolInfo.bLusdApr.mul(100).prettify(2)
+              : "N/A"
+          }
           unit="%"
         />
       </Statistic>
@@ -67,7 +71,9 @@ export const BondStats: React.FC<BondStatsProps> = () => {
       >
         <Metric
           value={
-            protocolInfo.yieldAmplification ? protocolInfo.yieldAmplification.prettify(2) : "N/A"
+            protocolInfo.yieldAmplification && protocolInfo.bLusdSupply.gt(0)
+              ? protocolInfo.yieldAmplification.prettify(2)
+              : "N/A"
           }
           unit="x"
         />

--- a/packages/dev-frontend/src/components/Bonds/lexicon.ts
+++ b/packages/dev-frontend/src/components/Bonds/lexicon.ts
@@ -134,7 +134,7 @@ export const CLAIM_BOND = {
 export const BLUSD_MARKET_PRICE = {
   term: "Market price",
   description:
-    "The current price of bLUSD according to the bLUSD/LUSD Curve pool. As long as the bLUSD/LUSD is empty, the market price shown corresponds to the initial Curve v2 price parameter used to initalize the pool."
+    "The current price of bLUSD according to the bLUSD Curve pool. As long as the bLUSD pool is empty, the market price shown corresponds to the initial Curve v2 price parameter used to initalize the pool."
 };
 
 export const BLUSD_FAIR_PRICE = {

--- a/packages/dev-frontend/src/components/Bonds/views/creating/Details.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/creating/Details.tsx
@@ -34,7 +34,7 @@ export const Details: React.FC<DetailsProps> = ({ onBack }) => {
   const depositEditingState = useState<string>();
   const isConfirming = useMemo(() => statuses.CREATE === "PENDING", [statuses.CREATE]);
   const handleBack = back ?? onBack ?? (() => dispatchEvent("BACK_PRESSED"));
-  const [isDepositEnough, setIsDepositEnough] = useState<boolean>(true);
+  const [isDepositEnough, setIsDepositEnough] = useState<boolean>(lusdBalance?.gte(100) ?? true);
   const [doesDepositExceedBalance, setDoesDepositExceedBalance] = useState<boolean>(false);
 
   const handleDismiss = () => {


### PR DESCRIPTION
- Show APR/yield-amplification as N/A until bLUSD enters the market
- If the user has less than 100 LUSD and opens the create bond dialog, show the insufficient funds error immediately
- Remove reference to bLUSD/LUSD Curve pool since its now bLUSD/LUSD-3CRV