### PR TITLE
Update browserslist support 

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
       "**/react-scripts"
     ]
   },
+  "engines": {
+    "node": ">=14.0.0 <17.0.0"
+  },
   "release": {
     "extends": "semantic-release-monorepo",
     "branches": [

--- a/packages/dev-frontend/package.json
+++ b/packages/dev-frontend/package.json
@@ -62,16 +62,11 @@
   "eslintConfig": {
     "extends": "react-app"
   },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  }
+  "browserslist": [
+    "chrome >= 67",
+    "edge >= 79",
+    "firefox >= 68",
+    "opera >= 54",
+    "safari >= 14"
+  ]
 }


### PR DESCRIPTION
BigInt support is required from cryptography dependencies etc. so this PR makes browserslist versions compatible.

See:
https://github.com/paulmillr/noble-ed25519/issues/23#issuecomment-1109248320
https://github.com/0xs34n/starknet.js/issues/37#issuecomment-955797303