### PR TITLE
Enable user to deposit liquidity balanced and show balance ratio

### DIFF
--- a/packages/dev-frontend/src/components/Bonds/views/managing/DepositPane.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/managing/DepositPane.tsx
@@ -20,7 +20,9 @@ export const DepositPane: React.FC = () => {
     isBLusdApprovedWithAmmZapper,
     isLusdApprovedWithAmmZapper,
     getExpectedLpTokens,
-    addresses
+    addresses,
+    bLusdAmmBLusdBalance,
+    bLusdAmmLusdBalance
   } = useBondView();
 
   const editingState = useState<string>();
@@ -28,6 +30,7 @@ export const DepositPane: React.FC = () => {
   const [lusdAmount, setLusdAmount] = useState<Decimal>(Decimal.ZERO);
   const [lpTokens, setLpTokens] = useState<Decimal>(Decimal.ZERO);
   const [shouldStakeInGauge, setShouldStakeInGauge] = useState(false);
+  const [shouldDepositBalanced, setShouldDepositBalanced] = useState(true);
 
   const coalescedBLusdBalance = bLusdBalance ?? Decimal.ZERO;
   const coalescedLusdBalance = lusdBalance ?? Decimal.ZERO;
@@ -44,6 +47,11 @@ export const DepositPane: React.FC = () => {
   const zapperNeedsLusdApproval = isDepositingLusd && !isLusdApprovedWithAmmZapper;
   const zapperNeedsBLusdApproval = isDepositingBLusd && !isBLusdApprovedWithAmmZapper;
   const isApprovalNeeded = zapperNeedsLusdApproval || zapperNeedsBLusdApproval;
+
+  const poolBalanceRatio =
+    bLusdAmmBLusdBalance && bLusdAmmLusdBalance
+      ? bLusdAmmLusdBalance.div(bLusdAmmBLusdBalance)
+      : Decimal.ONE;
 
   const handleApprovePressed = () => {
     const tokensNeedingApproval = new Map<BLusdAmmTokenIndex, Address>();
@@ -73,6 +81,24 @@ export const DepositPane: React.FC = () => {
 
   const handleToggleShouldStakeInGauge = () => {
     setShouldStakeInGauge(toggle => !toggle);
+  };
+
+  const handleToggleShouldDepositBalanced = () => {
+    if (!shouldDepositBalanced) {
+      setBLusdAmount(Decimal.ZERO);
+      setLusdAmount(Decimal.ZERO);
+    }
+    setShouldDepositBalanced(toggle => !toggle);
+  };
+
+  const handleSetAmount = (token: "bLUSD" | "LUSD", amount: Decimal) => {
+    if (shouldDepositBalanced) {
+      if (token === "bLUSD") setLusdAmount(amount.div(poolBalanceRatio));
+      else if (token === "LUSD") setBLusdAmount(poolBalanceRatio.mul(amount));
+    }
+
+    if (token === "bLUSD") setBLusdAmount(amount);
+    else if (token === "LUSD") setLusdAmount(amount);
   };
 
   useEffect(() => {
@@ -109,7 +135,7 @@ export const DepositPane: React.FC = () => {
         unit="bLUSD"
         editingState={editingState}
         editedAmount={bLusdAmount.toString()}
-        setEditedAmount={amount => setBLusdAmount(Decimal.from(amount))}
+        setEditedAmount={amount => handleSetAmount("bLUSD", Decimal.from(amount))}
         maxAmount={coalescedBLusdBalance.toString()}
         maxedOut={bLusdAmount.eq(coalescedBLusdBalance)}
       />
@@ -121,24 +147,37 @@ export const DepositPane: React.FC = () => {
         unit="LUSD"
         editingState={editingState}
         editedAmount={lusdAmount.toString()}
-        setEditedAmount={amount => setLusdAmount(Decimal.from(amount))}
+        setEditedAmount={amount => handleSetAmount("LUSD", Decimal.from(amount))}
         maxAmount={coalescedLusdBalance.toString()}
         maxedOut={lusdAmount.eq(coalescedLusdBalance)}
       />
 
-      {!isApprovalNeeded && (
-        <>
-          <Flex sx={{ justifyContent: "center", mb: 3 }}>
-            <Icon name="arrow-down" size="lg" />
-          </Flex>
+      <Flex sx={{ justifyContent: "center", mb: 3 }}>
+        <Icon name="arrow-down" size="lg" />
+      </Flex>
 
-          <DisabledEditableRow
-            label="Mint LP tokens"
-            inputId="deposit-mint-lp-tokens"
-            amount={lpTokens.prettify(2)}
+      <DisabledEditableRow
+        label="Mint LP tokens"
+        inputId="deposit-mint-lp-tokens"
+        amount={lpTokens.prettify(2)}
+      />
+
+      <Label>
+        <Flex sx={{ alignItems: "center" }}>
+          <Checkbox checked={shouldDepositBalanced} onChange={handleToggleShouldDepositBalanced} />
+          <Text sx={{ fontWeight: 300, fontSize: "16px" }}>Deposit tokens in a balanced ratio</Text>
+          <InfoIcon
+            placement="right"
+            size="xs"
+            tooltip={
+              <Card variant="tooltip">
+                Tick this box to deposit bLUSD and LUSD-3CRV in the pool's current liquidity ratio.
+                Current ratio = 1 bLUSD : {poolBalanceRatio.prettify(2)} LUSD.
+              </Card>
+            }
           />
-        </>
-      )}
+        </Flex>
+      </Label>
 
       <Label mb={2}>
         <Flex sx={{ alignItems: "center" }}>

--- a/packages/dev-frontend/src/components/Bonds/views/managing/DepositPane.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/managing/DepositPane.tsx
@@ -93,8 +93,8 @@ export const DepositPane: React.FC = () => {
 
   const handleSetAmount = (token: "bLUSD" | "LUSD", amount: Decimal) => {
     if (shouldDepositBalanced) {
-      if (token === "bLUSD") setLusdAmount(amount.div(poolBalanceRatio));
-      else if (token === "LUSD") setBLusdAmount(poolBalanceRatio.mul(amount));
+      if (token === "bLUSD") setLusdAmount(poolBalanceRatio.mul(amount));
+      else if (token === "LUSD") setBLusdAmount(amount.div(poolBalanceRatio));
     }
 
     if (token === "bLUSD") setBLusdAmount(amount);

--- a/packages/dev-frontend/src/components/Bonds/views/managing/PoolDetails.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/managing/PoolDetails.tsx
@@ -13,6 +13,10 @@ const PoolBalance: React.FC<{ symbol: string }> = ({ symbol, children }) => (
 
 export const PoolDetails: React.FC = () => {
   const { lpTokenSupply, bLusdAmmBLusdBalance, bLusdAmmLusdBalance } = useBondView();
+  const poolBalanceRatio =
+    bLusdAmmBLusdBalance && bLusdAmmLusdBalance
+      ? bLusdAmmLusdBalance.div(bLusdAmmBLusdBalance)
+      : Decimal.ONE;
 
   return (
     <details>
@@ -29,12 +33,21 @@ export const PoolDetails: React.FC = () => {
             <PoolBalance symbol="bLUSD">
               {(bLusdAmmBLusdBalance ?? Decimal.ZERO).prettify(2)}
             </PoolBalance>
-
             <Text sx={{ fontWeight: "light", mx: "12px" }}>+</Text>
-
             <PoolBalance symbol="LUSD">
               {(bLusdAmmLusdBalance ?? Decimal.ZERO).prettify(2)}
             </PoolBalance>
+          </StaticAmounts>
+        </StaticRow>
+
+        <StaticRow label="Pool balance ratio">
+          <StaticAmounts
+            sx={{ alignItems: "center", justifyContent: "flex-start" }}
+            inputId="deposit-pool-ratio"
+          >
+            <PoolBalance symbol="bLUSD">1</PoolBalance>
+            <Text sx={{ fontWeight: "thin", mx: "6px" }}>:</Text>
+            <PoolBalance symbol="LUSD">{poolBalanceRatio.prettify(2)}</PoolBalance>
           </StaticAmounts>
         </StaticRow>
 


### PR DESCRIPTION
All functionality is aligned with how Curve manages it on their UI, except for unticking the checkbox. In Curve it resets the amount fields to 0, in ours it leaves it as the last values entered since I would have thought this would be the more common path. But happy to change it to also reset if its a better UX. (Ticking still resets as expected since that would otherwise be a misleading state).

### New checkbox

![image](https://user-images.githubusercontent.com/5167260/197007006-bca06509-9aae-4ece-81ce-9bce2f7a7bb3.png)
----
----

### With tooltip

![image](https://user-images.githubusercontent.com/5167260/197007130-7a231a45-8442-4736-a8ae-a9c902c4949c.png)

----
----

### And included in pool details
C) ![image](https://user-images.githubusercontent.com/5167260/197007050-787ed30c-ca9b-46de-b087-70f67ef4c15a.png)
