### PR TITLE
Enable viewing and claiming LP rewards

### DIFF
--- a/packages/dev-frontend/src/components/Bonds/context/BondViewContext.tsx
+++ b/packages/dev-frontend/src/components/Bonds/context/BondViewContext.tsx
@@ -9,7 +9,8 @@ import type {
   ProtocolInfo,
   OptimisticBond,
   BLusdAmmTokenIndex,
-  Addresses
+  Addresses,
+  BLusdLpRewards
 } from "./transitions";
 import { PENDING_STATUS, CANCELLED_STATUS, CLAIMED_STATUS } from "../lexicon";
 import { Decimal } from "@liquity/lib-base";
@@ -54,6 +55,7 @@ export type BondViewContextType = {
   isBootstrapPeriodActive?: boolean;
   hasLoaded: boolean;
   addresses: Addresses;
+  lpRewards: BLusdLpRewards | undefined;
 };
 
 export const BondViewContext = createContext<BondViewContextType | null>(null);

--- a/packages/dev-frontend/src/components/Bonds/context/BondViewProvider.tsx
+++ b/packages/dev-frontend/src/components/Bonds/context/BondViewProvider.tsx
@@ -12,7 +12,8 @@ import type {
   OptimisticBond,
   SwapPayload,
   ApprovePressedPayload,
-  ManageLiquidityPayload
+  ManageLiquidityPayload,
+  BLusdLpRewards
 } from "./transitions";
 import { BLusdAmmTokenIndex } from "./transitions";
 import { transitions } from "./transitions";
@@ -50,6 +51,7 @@ export const BondViewProvider: React.FC = props => {
   const [stats, setStats] = useState<Stats>();
   const [protocolInfo, setProtocolInfo] = useState<ProtocolInfo>();
   const [simulatedProtocolInfo, setSimulatedProtocolInfo] = useState<ProtocolInfo>();
+  const [lpRewards, setLpRewards] = useState<BLusdLpRewards>();
   const [isLusdApprovedWithBlusdAmm, setIsLusdApprovedWithBlusdAmm] = useState(false);
   const [isBLusdApprovedWithBlusdAmm, setIsBLusdApprovedWithBlusdAmm] = useState(false);
   const [isLusdApprovedWithAmmZapper, setIsLusdApprovedWithAmmZapper] = useState(false);
@@ -285,7 +287,8 @@ export const BondViewProvider: React.FC = props => {
           stakedLpTokenBalance,
           lpTokenSupply,
           bLusdAmmBLusdBalance,
-          bLusdAmmLusdBalance
+          bLusdAmmLusdBalance,
+          lpRewards
         } = latest;
 
         setProtocolInfo(protocolInfo);
@@ -305,6 +308,7 @@ export const BondViewProvider: React.FC = props => {
           });
         }
 
+        setLpRewards(lpRewards);
         setBLusdBalance(bLusdBalance);
         setLusdBalance(lusdBalance);
         setLpTokenBalance(lpTokenBalance);
@@ -492,6 +496,8 @@ export const BondViewProvider: React.FC = props => {
         await api.stakeLiquidity(params.stakeAmount, contracts.bLusdGauge);
       } else if (params.action === "unstakeLiquidity") {
         await api.unstakeLiquidity(params.unstakeAmount, contracts.bLusdGauge);
+      } else if (params.action === "claimLpRewards") {
+        await api.claimLpRewards(contracts.bLusdGauge);
       }
       setShouldSynchronize(true);
     },
@@ -687,8 +693,9 @@ export const BondViewProvider: React.FC = props => {
     getExpectedLpTokens,
     getExpectedWithdrawal,
     isBootstrapPeriodActive,
-    hasLoaded: protocolInfo !== undefined,
-    addresses: contracts.addresses
+    hasLoaded: protocolInfo !== undefined && bonds !== undefined,
+    addresses: contracts.addresses,
+    lpRewards
   };
 
   // @ts-ignore

--- a/packages/dev-frontend/src/components/Bonds/context/transitions.ts
+++ b/packages/dev-frontend/src/components/Bonds/context/transitions.ts
@@ -174,12 +174,17 @@ export type UnstakeLiquidityPayload = {
   unstakeAmount: Decimal;
 };
 
+export type ClaimLpRewardsPayload = {
+  action: "claimLpRewards";
+};
+
 export type ManageLiquidityPayload =
   | AddLiquidityPayload
   | RemoveLiquidityPayload
   | RemoveLiquidityOneCoinPayload
   | StakeLiquidityPayload
-  | UnstakeLiquidityPayload;
+  | UnstakeLiquidityPayload
+  | ClaimLpRewardsPayload;
 
 export type Payload =
   | CreateBondPayload
@@ -265,3 +270,5 @@ export type BondTransactionStatuses = Record<BondTransaction, TransactionStatus>
 export type ClaimedBonds = Record<string, Decimal>;
 
 export type Maybe<T> = T | undefined;
+
+export type BLusdLpRewards = Array<{ name: string; address: string; amount: Decimal }>;

--- a/packages/dev-frontend/src/components/Bonds/context/useBondContracts.tsx
+++ b/packages/dev-frontend/src/components/Bonds/context/useBondContracts.tsx
@@ -1,4 +1,4 @@
-import type { Decimal } from "@liquity/lib-base";
+import { Decimal } from "@liquity/lib-base";
 import {
   BLUSDLPZap,
   BLUSDLPZap__factory,
@@ -24,7 +24,7 @@ import { useContract } from "../../../hooks/useContract";
 import { useLiquity } from "../../../hooks/LiquityContext";
 import { useCallback } from "react";
 import type { BondsApi } from "./api";
-import type { Bond, ProtocolInfo, Stats } from "./transitions";
+import type { BLusdLpRewards, Bond, ProtocolInfo, Stats } from "./transitions";
 import { BLusdAmmTokenIndex } from "./transitions";
 import type { Addresses } from "./transitions";
 import { useWeb3React } from "@web3-react/core";
@@ -42,6 +42,7 @@ type BondsInformation = {
   lpTokenSupply: Decimal;
   bLusdAmmBLusdBalance: Decimal;
   bLusdAmmLusdBalance: Decimal;
+  lpRewards: BLusdLpRewards;
 };
 
 type BondContracts = {
@@ -127,16 +128,17 @@ export const useBondContracts = (): BondContracts => {
     ].find(status => status === "FAILED") === undefined;
 
   const getLatestData = useCallback(
-    async (account: string, api: BondsApi) => {
+    async (account: string, api: BondsApi): Promise<BondsInformation | undefined> => {
       if (
         lusdToken === undefined ||
         bondNft === undefined ||
         chickenBondManager === undefined ||
         bLusdToken === undefined ||
         bLusdAmm === undefined ||
+        bLusdGauge === undefined ||
         BLUSD_AMM_STAKING_ADDRESS === null
       ) {
-        return;
+        return undefined;
       }
 
       const protocolInfo = await api.getProtocolInfo(
@@ -177,6 +179,8 @@ export const useBondContracts = (): BondContracts => {
         api.getCoinBalances(bLusdAmm)
       ]);
 
+      const lpRewards = await api.getLpRewards(account, bLusdGauge);
+
       return {
         protocolInfo,
         bonds,
@@ -187,7 +191,8 @@ export const useBondContracts = (): BondContracts => {
         stakedLpTokenBalance,
         lpTokenSupply,
         bLusdAmmBLusdBalance: bLusdAmmCoinBalances[BLusdAmmTokenIndex.BLUSD],
-        bLusdAmmLusdBalance: bLusdAmmCoinBalances[BLusdAmmTokenIndex.LUSD]
+        bLusdAmmLusdBalance: bLusdAmmCoinBalances[BLusdAmmTokenIndex.LUSD],
+        lpRewards
       };
     },
     [
@@ -197,7 +202,8 @@ export const useBondContracts = (): BondContracts => {
       lusdToken,
       bLusdAmm,
       isMainnet,
-      BLUSD_AMM_STAKING_ADDRESS
+      BLUSD_AMM_STAKING_ADDRESS,
+      bLusdGauge
     ]
   );
 

--- a/packages/dev-frontend/src/components/Bonds/views/managing/ManagingLiquidity.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/managing/ManagingLiquidity.tsx
@@ -6,6 +6,7 @@ import { DepositPane } from "./DepositPane";
 import { WithdrawPane } from "./WithdrawPane";
 import { StakePane } from "./StakePane";
 import { UnstakePane } from "./UnstakePane";
+import { RewardsPane } from "./RewardsPane";
 
 interface LinkProps extends NavLinkProps {
   active?: boolean;
@@ -19,9 +20,9 @@ const Link: React.FC<LinkProps> = ({ active, children, ...props }) => (
 
 export const ManagingLiquidity: React.FC = () => {
   const { dispatchEvent } = useBondView();
-  const [selectedPane, setSelectedPane] = useState<"deposit" | "withdraw" | "stake" | "unstake">(
-    "deposit"
-  );
+  const [selectedPane, setSelectedPane] = useState<
+    "deposit" | "withdraw" | "stake" | "unstake" | "claim"
+  >("deposit");
 
   const handleDismiss = () => {
     dispatchEvent("ABORT_PRESSED");
@@ -57,12 +58,17 @@ export const ManagingLiquidity: React.FC = () => {
         <Link active={selectedPane === "unstake"} onClick={() => setSelectedPane("unstake")}>
           Unstake
         </Link>
+
+        <Link active={selectedPane === "claim"} onClick={() => setSelectedPane("claim")}>
+          Rewards
+        </Link>
       </Flex>
 
       {selectedPane === "deposit" && <DepositPane />}
       {selectedPane === "withdraw" && <WithdrawPane />}
       {selectedPane === "stake" && <StakePane />}
       {selectedPane === "unstake" && <UnstakePane />}
+      {selectedPane === "claim" && <RewardsPane />}
     </ReactModal>
   );
 };

--- a/packages/dev-frontend/src/components/Bonds/views/managing/PendingRewards.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/managing/PendingRewards.tsx
@@ -7,12 +7,12 @@ export const PendingRewards: React.FC<{ open?: boolean }> = ({ open = false }) =
   const { lpRewards } = useBondView();
 
   return (
-    <details open={open}>
-      <Box as="summary" sx={{ cursor: "pointer", mb: 3, ml: 2 }}>
+    <>
+      <Box as="summary" sx={{ cursor: "pointer", mt: 1, mb: 2, ml: 2 }}>
         Rewards
       </Box>
 
-      <Flex sx={{ mt: 3 }}>
+      <Flex>
         {lpRewards?.map(reward => {
           console.log(reward, 1);
           return (
@@ -35,6 +35,6 @@ export const PendingRewards: React.FC<{ open?: boolean }> = ({ open = false }) =
           <Flex>You have no pending rewards</Flex>
         )}
       </Flex>
-    </details>
+    </>
   );
 };

--- a/packages/dev-frontend/src/components/Bonds/views/managing/PendingRewards.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/managing/PendingRewards.tsx
@@ -1,0 +1,40 @@
+import { Box, Card, Flex } from "theme-ui";
+import { InfoIcon } from "../../../InfoIcon";
+import { StaticRow } from "../../../Trove/Editor";
+import { useBondView } from "../../context/BondViewContext";
+
+export const PendingRewards: React.FC<{ open?: boolean }> = ({ open = false }) => {
+  const { lpRewards } = useBondView();
+
+  return (
+    <details open={open}>
+      <Box as="summary" sx={{ cursor: "pointer", mb: 3, ml: 2 }}>
+        Rewards
+      </Box>
+
+      <Flex sx={{ mt: 3 }}>
+        {lpRewards?.map(reward => {
+          console.log(reward, 1);
+          return (
+            <StaticRow
+              amount={reward.amount.shorten()}
+              label={
+                <Flex>
+                  {reward.name}
+                  <InfoIcon
+                    placement="right"
+                    size="xs"
+                    tooltip={<Card variant="tooltip">Reward token address: {reward.address}</Card>}
+                  />
+                </Flex>
+              }
+            />
+          );
+        })}
+        {(lpRewards === undefined || lpRewards?.length === 0) && (
+          <Flex>You have no pending rewards</Flex>
+        )}
+      </Flex>
+    </details>
+  );
+};

--- a/packages/dev-frontend/src/components/Bonds/views/managing/RewardsPane.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/managing/RewardsPane.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { Flex, Button, Spinner } from "theme-ui";
+import { useBondView } from "../../context/BondViewContext";
+import { PendingRewards } from "./PendingRewards";
+
+export const RewardsPane: React.FC = () => {
+  const { dispatchEvent, statuses, lpRewards } = useBondView();
+
+  const isManageLiquidityPending = statuses.MANAGE_LIQUIDITY === "PENDING";
+  const hasRewards = lpRewards?.find(reward => reward.amount.gt(0)) !== undefined;
+
+  const handleConfirmPressed = () => {
+    dispatchEvent("CONFIRM_PRESSED", {
+      action: "claimLpRewards"
+    });
+  };
+
+  const handleBackPressed = () => {
+    dispatchEvent("BACK_PRESSED");
+  };
+
+  return (
+    <>
+      <PendingRewards open />
+
+      <Flex variant="layout.actions">
+        <Button variant="cancel" onClick={handleBackPressed} disabled={isManageLiquidityPending}>
+          Back
+        </Button>
+
+        <Button variant="primary" onClick={handleConfirmPressed} disabled={!hasRewards}>
+          {isManageLiquidityPending ? (
+            <Spinner size="28px" sx={{ color: "white" }} />
+          ) : (
+            <>Claim all rewards</>
+          )}
+        </Button>
+      </Flex>
+    </>
+  );
+};

--- a/packages/dev-frontend/src/components/Bonds/views/managing/StakePane.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/managing/StakePane.tsx
@@ -1,6 +1,6 @@
 import { Decimal } from "@liquity/lib-base";
 import React, { useState } from "react";
-import { Flex, Button, Spinner, Text } from "theme-ui";
+import { Flex, Button, Spinner } from "theme-ui";
 import { Amount } from "../../../ActionDescription";
 import { ErrorDescription } from "../../../ErrorDescription";
 import { EditableRow } from "../../../Trove/Editor";
@@ -61,10 +61,10 @@ export const StakePane: React.FC = () => {
         maxedOut={stakeAmount.eq(coalescedLpTokenBalance)}
       />
 
-      <Text sx={{ fontWeight: 300, fontSize: "16px" }}>
+      <Flex my={3} sx={{ fontWeight: 300, fontSize: "16px" }}>
         Your LP tokens will be staked in the bLUSD Curve gauge to earn protocol fees and Curve
         rewards.
-      </Text>
+      </Flex>
 
       {isBalanceInsufficient && (
         <ErrorDescription>

--- a/packages/dev-frontend/src/components/Bonds/views/managing/UnstakePane.tsx
+++ b/packages/dev-frontend/src/components/Bonds/views/managing/UnstakePane.tsx
@@ -1,10 +1,11 @@
 import { Decimal } from "@liquity/lib-base";
 import React, { useState } from "react";
-import { Flex, Button, Spinner, Text } from "theme-ui";
+import { Flex, Button, Spinner } from "theme-ui";
 import { Amount } from "../../../ActionDescription";
 import { ErrorDescription } from "../../../ErrorDescription";
 import { EditableRow } from "../../../Trove/Editor";
 import { useBondView } from "../../context/BondViewContext";
+import { PendingRewards } from "./PendingRewards";
 
 export const UnstakePane: React.FC = () => {
   const { dispatchEvent, statuses, stakedLpTokenBalance } = useBondView();
@@ -40,9 +41,12 @@ export const UnstakePane: React.FC = () => {
         maxedOut={unstakeAmount.eq(coalescedStakedLpTokenBalance)}
       />
 
-      <Text sx={{ fontWeight: 300, fontSize: "16px" }}>
+      <PendingRewards open />
+
+      <Flex mb={3} sx={{ fontWeight: 300, fontSize: "16px" }}>
         Your staked LP tokens will be unstaked from the bLUSD Curve gauge and moved into your wallet.
-      </Text>
+        Pending rewards will also be claimed and moved into your wallet.
+      </Flex>
 
       {isBalanceInsufficient && (
         <ErrorDescription>

--- a/packages/dev-frontend/src/components/InfoIcon.tsx
+++ b/packages/dev-frontend/src/components/InfoIcon.tsx
@@ -10,7 +10,7 @@ export type InfoIconProps = Pick<TippyProps, "placement"> &
 
 export const InfoIcon: React.FC<InfoIconProps> = ({ placement = "right", tooltip, size = "1x" }) => {
   return (
-    <Tippy interactive={true} placement={placement} content={tooltip} maxWidth="268px">
+    <Tippy interactive={true} placement={placement} content={tooltip} maxWidth="364px">
       <span>
         &nbsp;
         <Icon name="question-circle" size={size} />

--- a/packages/dev-frontend/src/components/Trove/Editor.tsx
+++ b/packages/dev-frontend/src/components/Trove/Editor.tsx
@@ -4,7 +4,7 @@ import { Text, Flex, Label, Input, SxProp, Button, ThemeUICSSProperties } from "
 import { Icon } from "../Icon";
 
 type RowProps = SxProp & {
-  label: string;
+  label: string | React.ReactNode;
   labelId?: string;
   labelFor?: string;
   infoIcon?: React.ReactNode;


### PR DESCRIPTION
#### Unstake now shows any pending rewards
<img width="554" alt="image" src="https://user-images.githubusercontent.com/5167260/197574753-a6bfc46b-59ed-4df6-9aaf-08ba076e16df.png">


#### New tab "Rewards" enables user to view and claim their rewards
<img width="554" alt="image" src="https://user-images.githubusercontent.com/5167260/197574829-adfd00a3-638f-4b7d-88a5-c6575cc316a4.png">
