### PR TITLE
Use current floor price for bonding calculations

### DIFF
--- a/packages/dev-frontend/src/components/BondStats.tsx
+++ b/packages/dev-frontend/src/components/BondStats.tsx
@@ -53,7 +53,7 @@ export const BondStats: React.FC<BondStatsProps> = () => {
         />
       </Statistic>
       <Statistic name={l.BLUSD_FLOOR_PRICE.term} tooltip={l.BLUSD_FLOOR_PRICE.description}>
-        <Metric value={protocolInfo.floorPrice.prettify(4)} unit="LUSD" />
+        <Metric value={protocolInfo.floorPriceWithoutPendingHarvests.prettify(4)} unit="LUSD" />
       </Statistic>
       <Statistic name={l.BLUSD_APR.term} tooltip={l.BLUSD_APR.description}>
         <Metric

--- a/packages/dev-frontend/src/components/Bonds/context/api.ts
+++ b/packages/dev-frontend/src/components/Bonds/context/api.ts
@@ -554,6 +554,10 @@ const getProtocolInfo = async (
 
   const floorPrice = bLusdSupply.isZero
     ? Decimal.ONE
+    : decimalify(await chickenBondManager.calcSystemBackingRatio());
+
+  const floorPriceWithoutPendingHarvests = bLusdSupply.isZero
+    ? Decimal.ONE
     : await getFloorPrice(chickenBondManager, bLusdSupply);
 
   const claimBondFee = decimalify(await chickenBondManager.CHICKEN_IN_AMM_FEE());
@@ -600,7 +604,8 @@ const getProtocolInfo = async (
     bLusdApr,
     bLusdLpApr,
     controllerTargetAge,
-    averageBondAge
+    averageBondAge,
+    floorPriceWithoutPendingHarvests
   };
 };
 

--- a/packages/dev-frontend/src/components/Bonds/context/transitions.ts
+++ b/packages/dev-frontend/src/components/Bonds/context/transitions.ts
@@ -238,6 +238,7 @@ export type ProtocolInfo = {
   bLusdLpApr?: Decimal;
   controllerTargetAge: Decimal;
   averageBondAge: Decimal;
+  floorPriceWithoutPendingHarvests: Decimal;
 };
 
 export type TransactionStatus = "IDLE" | "PENDING" | "CONFIRMED" | "FAILED";


### PR DESCRIPTION
No change:
- For bond stats show the floor price without Reserve pending harvests considered (to avoid the floor price appearing to go down)

Change:
- For bond estimations use the floor price "at next chicken in" value (since this is the value the smart contract uses)