### PR TITLE
chore: automatically prepare after installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,6 @@ jobs:
           FORCE_COLOR: 0
 
       - run: yarn install --immutable
-      - run: yarn prepare
       - run: yarn build
 
       - name: Test SDK & UI

--- a/.github/workflows/test-contracts.yml
+++ b/.github/workflows/test-contracts.yml
@@ -28,7 +28,6 @@ jobs:
           FORCE_COLOR: 0
 
       - run: yarn install --immutable
-      - run: yarn prepare
 
       - name: Test contracts
         run: yarn test-contracts
@@ -52,7 +51,6 @@ jobs:
           FORCE_COLOR: 0
 
       - run: yarn install --immutable
-      - run: yarn prepare
 
       - name: Test contract coverage
         run: yarn coverage

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "docs:collect-sdk-apis": "node scripts/collect-sdk-apis.js",
     "docs:api-documenter": "api-documenter generate -i temp/sdk-apis -o docs/sdk",
     "fuzzer": "yarn workspace @liquity/fuzzer fuzzer",
+    "postinstall": "run-s prepare",
     "prepare": "run-s 'prepare:*'",
     "prepare:contracts": "yarn workspace @liquity/contracts prepare",
     "prepare:lib-base": "yarn workspace @liquity/lib-base prepare",


### PR DESCRIPTION
Yarn v1 used to do this. Yarn v2 and later no longer do it, so let's add it back.