### PR TITLE
Replace unavailable dependency

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7965,9 +7965,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"concat-stream@github:hugomrdias/concat-stream#feat/smaller":
+"concat-stream@github:maxogden/concat-stream#feat/smaller":
   version: 2.0.0
-  resolution: "concat-stream@https://github.com/hugomrdias/concat-stream.git#commit=057bc7b5d6d8df26c8cf00a3f151b6721a0a8034"
+  resolution: "concat-stream@https://github.com/maxogden/concat-stream.git#commit=057bc7b5d6d8df26c8cf00a3f151b6721a0a8034"
   dependencies:
     inherits: ^2.0.3
     readable-stream: ^3.0.2
@@ -12976,7 +12976,7 @@ __metadata:
     bs58: ^4.0.1
     buffer: ^5.4.2
     cids: ~0.7.1
-    concat-stream: "github:hugomrdias/concat-stream#feat/smaller"
+    concat-stream: "github:maxogden/concat-stream#feat/smaller"
     debug: ^4.1.0
     detect-node: ^2.0.4
     end-of-stream: ^1.4.1
@@ -13005,7 +13005,7 @@ __metadata:
     multibase: ~0.6.0
     multicodec: ~0.5.1
     multihashes: ~0.4.14
-    ndjson: "github:hugomrdias/ndjson#feat/readable-stream3"
+    ndjson: "github:maxogden/ndjson#feat/readable-stream3"
     once: ^1.4.0
     peer-id: ~0.12.3
     peer-info: ~0.15.1
@@ -16363,9 +16363,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ndjson@github:hugomrdias/ndjson#feat/readable-stream3":
+"ndjson@github:maxogden/ndjson#feat/readable-stream3":
   version: 1.5.0
-  resolution: "ndjson@https://github.com/hugomrdias/ndjson.git#commit=4db16da6b42e5b39bf300c3a7cde62abb3fa3a11"
+  resolution: "ndjson@https://github.com/maxogden/ndjson.git#commit=4db16da6b42e5b39bf300c3a7cde62abb3fa3a11"
   dependencies:
     json-stringify-safe: ^5.0.1
     minimist: ^1.2.0

--- a/yarn.public.lock
+++ b/yarn.public.lock
@@ -7333,9 +7333,9 @@ concat-stream@^1.5.0, concat-stream@^1.6.0, concat-stream@^1.6.2, concat-stream@
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-"concat-stream@github:hugomrdias/concat-stream#feat/smaller":
+"concat-stream@github:maxogden/concat-stream#feat/smaller":
   version "2.0.0"
-  resolved "https://codeload.github.com/hugomrdias/concat-stream/tar.gz/057bc7b5d6d8df26c8cf00a3f151b6721a0a8034"
+  resolved "https://codeload.github.com/maxogden/concat-stream/tar.gz/057bc7b5d6d8df26c8cf00a3f151b6721a0a8034"
   dependencies:
     inherits "^2.0.3"
     readable-stream "^3.0.2"
@@ -11901,7 +11901,7 @@ ipfs-http-client@^34.0.0:
     bs58 "^4.0.1"
     buffer "^5.4.2"
     cids "~0.7.1"
-    concat-stream "github:hugomrdias/concat-stream#feat/smaller"
+    concat-stream "github:maxogden/concat-stream#feat/smaller"
     debug "^4.1.0"
     detect-node "^2.0.4"
     end-of-stream "^1.4.1"
@@ -11930,7 +11930,7 @@ ipfs-http-client@^34.0.0:
     multibase "~0.6.0"
     multicodec "~0.5.1"
     multihashes "~0.4.14"
-    ndjson "github:hugomrdias/ndjson#feat/readable-stream3"
+    ndjson "github:maxogden/ndjson#feat/readable-stream3"
     once "^1.4.0"
     peer-id "~0.12.3"
     peer-info "~0.15.1"
@@ -15164,9 +15164,9 @@ natural-orderby@^2.0.1:
   resolved "https://registry.yarnpkg.com/natural-orderby/-/natural-orderby-2.0.3.tgz#8623bc518ba162f8ff1cdb8941d74deb0fdcc016"
   integrity sha512-p7KTHxU0CUrcOXe62Zfrb5Z13nLvPhSWR/so3kFulUQU0sgUll2Z0LwpsLN351eOOD+hRGu/F1g+6xDfPeD++Q==
 
-"ndjson@github:hugomrdias/ndjson#feat/readable-stream3":
+"ndjson@github:maxogden/ndjson#feat/readable-stream3":
   version "1.5.0"
-  resolved "https://codeload.github.com/hugomrdias/ndjson/tar.gz/4db16da6b42e5b39bf300c3a7cde62abb3fa3a11"
+  resolved "https://codeload.github.com/maxogden/ndjson/tar.gz/4db16da6b42e5b39bf300c3a7cde62abb3fa3a11"
   dependencies:
     json-stringify-safe "^5.0.1"
     minimist "^1.2.0"


### PR DESCRIPTION
closes #1028 

As mentioned in the linked issue, running `yarn install` in the repo currently fails because one of the dependencies was removed from github. 
This PR fixes that by replacing the github owner of the dependency as suggested in the issue.