### PR TITLE
docs: fix typos in ITellor.sol NatSpec comments

### DIFF
--- a/packages/contracts/contracts/Dependencies/ITellor.sol
+++ b/packages/contracts/contracts/Dependencies/ITellor.sol
@@ -527,9 +527,9 @@ interface ITellor {
         returns (bool);
 
     /**
-     * @dev Retreive value from oracle based on timestamp
+     * @dev Retrieve value from oracle based on timestamp
      * @param _requestId being requested
-     * @param _timestamp to retreive data/value from
+     * @param _timestamp to retrieve data/value from
      * @return value for timestamp submitted
      */
     function retrieveData(uint256 _requestId, uint256 _timestamp)


### PR DESCRIPTION
Fix spelling errors in NatSpec documentation:

- 'Retreive' → 'Retrieve' in @dev comment (line 530)
- 'retreive' → 'retrieve' in @param description (line 532)

These are documentation-only changes with no functional impact.